### PR TITLE
Makes Good Clean Fun restock box work with Umbra machine

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Specific/Service/vending_machine_restock.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Service/vending_machine_restock.yml
@@ -232,6 +232,7 @@
   - type: VendingMachineRestock
     canRestock:
     - GoodCleanFunInventory
+    - GoodCleanFunInventoryUmbra # Sector Umbra
   - type: Sprite
     layers:
     - state: base


### PR DESCRIPTION
## About the PR
Allow the Good Clean Fun restock box to work with our special Umbra inventory.

## Why / Balance
More figurines to feed Deeja's addiction.

## Technical details
There are basically two ways this could be done. I could add a whole new Good Clean Fun restock box crate with its own restock box to replace the old one, but that would still require modifying upstream content, and it'd be quite a few lines of code and would result in item duplication, might require migrations, etc.

The second option is to add the Umbra inventory to the existing restock box. Single line of YAML. That's what I went with. This also ensures any Good Clean Fun vending machines that _haven't_ been affected by migrations (for whatever reason, maybe they break in a future upstream merge) can still be restocked.

## Media
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
no

**Changelog**
:cl:
- fix: Good Clean Fun restock boxes now work again.