### PR TITLE
Personal item loadouts

### DIFF
--- a/Content.Client/Preferences/UI/LoadoutGroupContainer.xaml.cs
+++ b/Content.Client/Preferences/UI/LoadoutGroupContainer.xaml.cs
@@ -31,6 +31,7 @@ public sealed partial class LoadoutGroupContainer : BoxContainer
     public void RefreshLoadouts(RoleLoadout loadout, ICommonSession session, IDependencyCollection collection)
     {
         var protoMan = collection.Resolve<IPrototypeManager>();
+        var prefMan = collection.Resolve<IClientPreferencesManager>(); // Umbra: personal items
         var loadoutSystem = collection.Resolve<IEntityManager>().System<LoadoutSystem>();
         RestrictionsContainer.DisposeAllChildren();
 
@@ -65,6 +66,7 @@ public sealed partial class LoadoutGroupContainer : BoxContainer
         // Didn't use options because this is more robust in future.
 
         var selected = loadout.SelectedLoadouts[_groupProto.ID];
+        var profile = prefMan.Preferences?.SelectedCharacter; // Umbra: personal items
 
         foreach (var loadoutProto in _groupProto.Loadouts)
         {
@@ -74,7 +76,8 @@ public sealed partial class LoadoutGroupContainer : BoxContainer
             var matchingLoadout = selected.FirstOrDefault(e => e.Prototype == loadoutProto);
             var pressed = matchingLoadout != null;
 
-            var enabled = loadout.IsValid(session, loadoutProto, collection, out var reason);
+            // Umbra: pass character profile
+            var enabled = loadout.IsValid(session, loadoutProto, profile, collection, out var reason);
             var loadoutContainer = new LoadoutContainer(loadoutProto, !enabled, reason);
             loadoutContainer.Select.Pressed = pressed;
             loadoutContainer.Text = loadoutSystem.GetName(loadProto);

--- a/Content.Client/Preferences/UI/RequirementsSelector.cs
+++ b/Content.Client/Preferences/UI/RequirementsSelector.cs
@@ -119,6 +119,7 @@ public abstract class RequirementsSelector<T> : BoxContainer where T : IPrototyp
         // else
         else
         {
+            var prefMan = collection.Resolve<IClientPreferencesManager>(); // Umbra: personal items
             var session = collection.Resolve<IPlayerManager>().LocalSession!;
             // TODO: Most of lobby state should be a uicontroller
             // trying to handle all this shit is a big-ass mess.
@@ -150,7 +151,8 @@ public abstract class RequirementsSelector<T> : BoxContainer where T : IPrototyp
                         if (!_loadout.RemoveLoadout(selectedGroup, selectedLoadout, protoManager))
                             return;
 
-                        _loadout.EnsureValid(session, collection);
+                        // Umbra: pass character profile
+                        _loadout.EnsureValid(session, prefMan.Preferences?.SelectedCharacter, collection);
                         _loadoutWindow.RefreshLoadouts(_loadout, session, collection);
                         var controller = UserInterfaceManager.GetUIController<LobbyUIController>();
                         controller.ReloadProfile();
@@ -162,7 +164,8 @@ public abstract class RequirementsSelector<T> : BoxContainer where T : IPrototyp
                         if (!_loadout.AddLoadout(selectedGroup, selectedLoadout, protoManager))
                             return;
 
-                        _loadout.EnsureValid(session, collection);
+                        // Umbra: pass character profile
+                        _loadout.EnsureValid(session, prefMan.Preferences?.SelectedCharacter, collection);
                         _loadoutWindow.RefreshLoadouts(_loadout, session, collection);
                         var controller = UserInterfaceManager.GetUIController<LobbyUIController>();
                         controller.ReloadProfile();

--- a/Content.Shared/Preferences/HumanoidCharacterProfile.cs
+++ b/Content.Shared/Preferences/HumanoidCharacterProfile.cs
@@ -553,7 +553,8 @@ namespace Content.Shared.Preferences
                     continue;
                 }
 
-                loadouts.EnsureValid(session, collection);
+                // Umbra: pass character profile
+                loadouts.EnsureValid(session, this, collection);
             }
 
             foreach (var value in toRemove)

--- a/Content.Shared/Preferences/Loadouts/Effects/GroupLoadoutEffect.cs
+++ b/Content.Shared/Preferences/Loadouts/Effects/GroupLoadoutEffect.cs
@@ -13,13 +13,19 @@ public sealed partial class GroupLoadoutEffect : LoadoutEffect
     [DataField(required: true)]
     public ProtoId<LoadoutEffectGroupPrototype> Proto;
 
-    public override bool Validate(RoleLoadout loadout, ICommonSession session, IDependencyCollection collection, [NotNullWhen(false)] out FormattedMessage? reason)
+    public override bool Validate(
+        RoleLoadout loadout,
+        ICommonSession session,
+        ICharacterProfile? profile, // Umbra: required for personal items
+        IDependencyCollection collection,
+        [NotNullWhen(false)] out FormattedMessage? reason)
     {
         var effectsProto = collection.Resolve<IPrototypeManager>().Index(Proto);
 
         foreach (var effect in effectsProto.Effects)
         {
-            if (!effect.Validate(loadout, session, collection, out reason))
+            // Umbra: pass character profile
+            if (!effect.Validate(loadout, session, profile, collection, out reason))
                 return false;
         }
 

--- a/Content.Shared/Preferences/Loadouts/Effects/JobRequirementLoadoutEffect.cs
+++ b/Content.Shared/Preferences/Loadouts/Effects/JobRequirementLoadoutEffect.cs
@@ -15,7 +15,12 @@ public sealed partial class JobRequirementLoadoutEffect : LoadoutEffect
     [DataField(required: true)]
     public JobRequirement Requirement = default!;
 
-    public override bool Validate(RoleLoadout loadout, ICommonSession session, IDependencyCollection collection, [NotNullWhen(false)] out FormattedMessage? reason)
+    public override bool Validate(
+        RoleLoadout loadout,
+        ICommonSession session,
+        ICharacterProfile? profile, // Umbra: required for personal items
+        IDependencyCollection collection,
+        [NotNullWhen(false)] out FormattedMessage? reason)
     {
         var manager = collection.Resolve<ISharedPlaytimeManager>();
         var playtimes = manager.GetPlayTimes(session);

--- a/Content.Shared/Preferences/Loadouts/Effects/LoadoutEffect.cs
+++ b/Content.Shared/Preferences/Loadouts/Effects/LoadoutEffect.cs
@@ -13,6 +13,7 @@ public abstract partial class LoadoutEffect
     public abstract bool Validate(
         RoleLoadout loadout,
         ICommonSession session,
+        ICharacterProfile? profile, // Umbra: required for personal items
         IDependencyCollection collection,
         [NotNullWhen(false)] out FormattedMessage? reason);
 

--- a/Content.Shared/Preferences/Loadouts/Effects/PersonalItemLoadoutEffect.cs
+++ b/Content.Shared/Preferences/Loadouts/Effects/PersonalItemLoadoutEffect.cs
@@ -23,15 +23,16 @@ public sealed partial class PersonalItemLoadoutEffect : LoadoutEffect
         IDependencyCollection collection,
         [NotNullWhen(false)] out FormattedMessage? reason)
     {
-        if (profile is HumanoidCharacterProfile humanoid && humanoid.Name != CharacterName)
+        if (profile is HumanoidCharacterProfile humanoid &&
+            humanoid.Name.Equals(CharacterName, StringComparison.InvariantCultureIgnoreCase))
         {
-            reason = FormattedMessage.FromUnformatted(Loc.GetString(
-                "loadout-personal-item-belongs-to",
-                ("character", CharacterName)));
-            return false;
+            reason = null;
+            return true;
         }
 
-        reason = null;
-        return true;
+        reason = FormattedMessage.FromUnformatted(Loc.GetString(
+            "loadout-personal-item-belongs-to",
+            ("character", CharacterName)));
+        return false;
     }
 }

--- a/Content.Shared/Preferences/Loadouts/Effects/PersonalItemLoadoutEffect.cs
+++ b/Content.Shared/Preferences/Loadouts/Effects/PersonalItemLoadoutEffect.cs
@@ -1,0 +1,37 @@
+using System.Diagnostics.CodeAnalysis;
+using Robust.Shared.Player;
+using Robust.Shared.Utility;
+
+namespace Content.Shared.Preferences.Loadouts.Effects;
+
+/// <summary>
+///     Implements a loadout effect that restricts items to a specific character,
+///     based on the currently selected character's name.
+/// </summary>
+/// <remarks>
+///     Sector Umbra
+/// </remarks>
+public sealed partial class PersonalItemLoadoutEffect : LoadoutEffect
+{
+    [DataField("character", required: true)]
+    public string CharacterName = default!;
+
+    public override bool Validate(
+        RoleLoadout loadout,
+        ICommonSession session,
+        ICharacterProfile? profile,
+        IDependencyCollection collection,
+        [NotNullWhen(false)] out FormattedMessage? reason)
+    {
+        if (profile is HumanoidCharacterProfile humanoid && humanoid.Name != CharacterName)
+        {
+            reason = FormattedMessage.FromUnformatted(Loc.GetString(
+                "loadout-personal-item-belongs-to",
+                ("character", CharacterName)));
+            return false;
+        }
+
+        reason = null;
+        return true;
+    }
+}

--- a/Content.Shared/Preferences/Loadouts/Effects/PointsCostLoadoutEffect.cs
+++ b/Content.Shared/Preferences/Loadouts/Effects/PointsCostLoadoutEffect.cs
@@ -13,6 +13,7 @@ public sealed partial class PointsCostLoadoutEffect : LoadoutEffect
     public override bool Validate(
         RoleLoadout loadout,
         ICommonSession session,
+        ICharacterProfile? profile, // Umbra: required for personal items
         IDependencyCollection collection,
         [NotNullWhen(false)] out FormattedMessage? reason)
     {

--- a/Content.Shared/Preferences/Loadouts/RoleLoadout.cs
+++ b/Content.Shared/Preferences/Loadouts/RoleLoadout.cs
@@ -44,7 +44,10 @@ public sealed class RoleLoadout
     /// <summary>
     /// Ensures all prototypes exist and effects can be applied.
     /// </summary>
-    public void EnsureValid(ICommonSession session, IDependencyCollection collection)
+    public void EnsureValid(
+        ICommonSession session,
+        ICharacterProfile? profile, // Umbra: required for personal items
+        IDependencyCollection collection)
     {
         var groupRemove = new ValueList<string>();
         var protoManager = collection.Resolve<IPrototypeManager>();
@@ -81,7 +84,8 @@ public sealed class RoleLoadout
                 }
 
                 // Validate the loadout can be applied (e.g. points).
-                if (!IsValid(session, loadout.Prototype, collection, out _))
+                // Umbra: pass character profile
+                if (!IsValid(session, loadout.Prototype, profile, collection, out _))
                 {
                     loadouts.RemoveAt(i);
                     continue;
@@ -167,7 +171,12 @@ public sealed class RoleLoadout
     /// <summary>
     /// Returns whether a loadout is valid or not.
     /// </summary>
-    public bool IsValid(ICommonSession session, ProtoId<LoadoutPrototype> loadout, IDependencyCollection collection, [NotNullWhen(false)] out FormattedMessage? reason)
+    public bool IsValid(
+        ICommonSession session,
+        ProtoId<LoadoutPrototype> loadout,
+        ICharacterProfile? profile, // Umbra: required for personal items
+        IDependencyCollection collection,
+        [NotNullWhen(false)] out FormattedMessage? reason)
     {
         reason = null;
 
@@ -190,7 +199,8 @@ public sealed class RoleLoadout
 
         foreach (var effect in loadoutProto.Effects)
         {
-            valid = valid && effect.Validate(this, session, collection, out reason);
+            // Umbra: pass character profile
+            valid = valid && effect.Validate(this, session, profile, collection, out reason);
         }
 
         return valid;

--- a/Resources/Locale/en-US/_Umbra/preferences/loadouts.ftl
+++ b/Resources/Locale/en-US/_Umbra/preferences/loadouts.ftl
@@ -1,0 +1,3 @@
+loadout-group-personal-items = Personal items
+
+loadout-personal-item-belongs-to = This item belongs to {$character}

--- a/Resources/Prototypes/Loadouts/role_loadouts.yml
+++ b/Resources/Prototypes/Loadouts/role_loadouts.yml
@@ -8,6 +8,7 @@
   - CaptainBackpack
   - CaptainOuterClothing
   - Trinkets
+  - PersonalItemsJobAgnostic # Umbra
 
 - type: roleLoadout
   id: JobHeadOfPersonnel
@@ -19,6 +20,7 @@
   - HoPOuterClothing
   - Glasses
   - Trinkets
+  - PersonalItemsJobAgnostic # Umbra
 
 # Civilian
 - type: roleLoadout
@@ -32,6 +34,7 @@
   - PassengerShoes
   - Glasses
   - Trinkets
+  - PersonalItemsJobAgnostic # Umbra
 
 - type: roleLoadout
   id: JobBartender
@@ -42,6 +45,7 @@
   - BartenderOuterClothing
   - Glasses
   - Trinkets
+  - PersonalItemsJobAgnostic # Umbra
 
 - type: roleLoadout
   id: JobServiceWorker
@@ -50,6 +54,7 @@
   - CommonBackpack
   - Glasses
   - Trinkets
+  - PersonalItemsJobAgnostic # Umbra
 
 - type: roleLoadout
   id: JobChef
@@ -61,6 +66,7 @@
   - ChefOuterClothing
   - Glasses
   - Trinkets
+  - PersonalItemsJobAgnostic # Umbra
 
 - type: roleLoadout
   id: JobLibrarian
@@ -69,6 +75,7 @@
   - CommonBackpack
   - Glasses
   - Trinkets
+  - PersonalItemsJobAgnostic # Umbra
 
 - type: roleLoadout
   id: JobLawyer
@@ -78,6 +85,7 @@
   - LawyerBackpack
   - Glasses
   - Trinkets
+  - PersonalItemsJobAgnostic # Umbra
 
 - type: roleLoadout
   id: JobChaplain
@@ -90,6 +98,7 @@
   - ChaplainOuterClothing
   - Glasses
   - Trinkets
+  - PersonalItemsJobAgnostic # Umbra
 
 - type: roleLoadout
   id: JobJanitor
@@ -101,6 +110,7 @@
   - JanitorOuterClothing
   - Glasses
   - Trinkets
+  - PersonalItemsJobAgnostic # Umbra
 
 - type: roleLoadout
   id: JobBotanist
@@ -111,6 +121,7 @@
   - BotanistOuterClothing
   - Glasses
   - Trinkets
+  - PersonalItemsJobAgnostic # Umbra
 
 - type: roleLoadout
   id: JobClown
@@ -122,6 +133,7 @@
   - ClownShoes
   - Glasses
   - Trinkets
+  - PersonalItemsJobAgnostic # Umbra
 
 - type: roleLoadout
   id: JobMime
@@ -133,6 +145,7 @@
   - MimeOuterClothing
   - Glasses
   - Trinkets
+  - PersonalItemsJobAgnostic # Umbra
 
 - type: roleLoadout
   id: JobMusician
@@ -141,6 +154,7 @@
   - MusicianOuterClothing
   - Glasses
   - Trinkets
+  - PersonalItemsJobAgnostic # Umbra
 
 # Cargo
 - type: roleLoadout
@@ -154,6 +168,7 @@
   - QuartermasterShoes
   - Glasses
   - Trinkets
+  - PersonalItemsJobAgnostic # Umbra
 
 - type: roleLoadout
   id: JobCargoTechnician
@@ -165,6 +180,7 @@
   - CargoTechnicianShoes
   - Glasses
   - Trinkets
+  - PersonalItemsJobAgnostic # Umbra
 
 - type: roleLoadout
   id: JobSalvageSpecialist
@@ -174,6 +190,7 @@
   - SalvageSpecialistShoes
   - Glasses
   - Trinkets
+  - PersonalItemsJobAgnostic # Umbra
 
 # Engineering
 - type: roleLoadout
@@ -186,6 +203,7 @@
   - ChiefEngineerOuterClothing
   - ChiefEngineerShoes
   - Trinkets
+  - PersonalItemsJobAgnostic # Umbra
 
 - type: roleLoadout
   id: JobTechnicalAssistant
@@ -193,6 +211,7 @@
   - TechnicalAssistantJumpsuit
   - StationEngineerBackpack
   - Trinkets
+  - PersonalItemsJobAgnostic # Umbra
 
 - type: roleLoadout
   id: JobStationEngineer
@@ -204,6 +223,7 @@
   - StationEngineerShoes
   - StationEngineerID
   - Trinkets
+  - PersonalItemsJobAgnostic # Umbra
 
 - type: roleLoadout
   id: JobAtmosphericTechnician
@@ -213,6 +233,7 @@
   - AtmosphericTechnicianOuterClothing
   - AtmosphericTechnicianShoes
   - Trinkets
+  - PersonalItemsJobAgnostic # Umbra
 
 # Science
 - type: roleLoadout
@@ -227,6 +248,7 @@
   - ResearchDirectorShoes
   - Glasses
   - Trinkets
+  - PersonalItemsJobAgnostic # Umbra
 
 - type: roleLoadout
   id: JobScientist
@@ -241,6 +263,7 @@
   - ScientistPDA
   - Glasses
   - Trinkets
+  - PersonalItemsJobAgnostic # Umbra
 
 - type: roleLoadout
   id: JobResearchAssistant
@@ -249,6 +272,7 @@
   - ScientistBackpack
   - Glasses
   - Trinkets
+  - PersonalItemsJobAgnostic # Umbra
 
 # Security
 - type: roleLoadout
@@ -263,6 +287,7 @@
   - SecurityShoes
   - SecurityGlassesOrHud # CD Addition
   - Trinkets
+  - PersonalItemsHoS # Umbra
 
 - type: roleLoadout
   id: JobWarden
@@ -275,6 +300,7 @@
   - SecurityShoes
   - SecurityGlassesOrHud # CD Addition
   - Trinkets
+  - PersonalItemsJobAgnostic # Umbra
 
 - type: roleLoadout
   id: JobSecurityOfficer
@@ -288,6 +314,7 @@
   - SecurityBelt
   - SecurityGlassesOrHud # CD Addition
   - Trinkets
+  - PersonalItemsJobAgnostic # Umbra
 
 - type: roleLoadout
   id: JobDetective
@@ -300,6 +327,7 @@
   - SecurityShoes
   - SecurityGlassesOrHud # CD Addition
   - Trinkets
+  - PersonalItemsDetective # Umbra
 
 - type: roleLoadout
   id: JobSecurityCadet
@@ -308,6 +336,7 @@
   - SecurityBackpack
   - SecurityGlassesOrHud # CD Addition
   - Trinkets
+  - PersonalItemsJobAgnostic # Umbra
 
 # Medical
 - type: roleLoadout
@@ -323,6 +352,7 @@
   - ChiefMedicalOfficerShoes
   - Glasses
   - Trinkets
+  - PersonalItemsJobAgnostic # Umbra
 
 - type: roleLoadout
   id: JobMedicalDoctor
@@ -337,6 +367,7 @@
   - MedicalDoctorPDA
   - Glasses
   - Trinkets
+  - PersonalItemsJobAgnostic # Umbra
 
 - type: roleLoadout
   id: JobMedicalIntern
@@ -345,6 +376,7 @@
   - MedicalBackpack
   - Glasses
   - Trinkets
+  - PersonalItemsJobAgnostic # Umbra
 
 - type: roleLoadout
   id: JobChemist
@@ -356,6 +388,7 @@
   - ChemistOuterClothing
   - MedicalShoes
   - Trinkets
+  - PersonalItemsJobAgnostic # Umbra
 
 - type: roleLoadout
   id: JobParamedic
@@ -371,6 +404,7 @@
   - ParamedicShoes
   - Glasses
   - Trinkets
+  - PersonalItemsJobAgnostic # Umbra
 
 # Wildcards
 - type: roleLoadout
@@ -379,6 +413,7 @@
   - CommonBackpack
   - Glasses
   - Trinkets
+  - PersonalItemsJobAgnostic # Umbra
 
 - type: roleLoadout
   id: JobReporter
@@ -387,6 +422,7 @@
   - CommonBackpack
   - Glasses
   - Trinkets
+  - PersonalItemsJobAgnostic # Umbra
 
 - type: roleLoadout
   id: JobPsychologist
@@ -394,6 +430,7 @@
   - MedicalBackpack
   - Glasses
   - Trinkets
+  - PersonalItemsJobAgnostic # Umbra
 
 - type: roleLoadout
   id: JobBoxer
@@ -403,3 +440,4 @@
   - CommonBackpack
   - Glasses
   - Trinkets
+  - PersonalItemsJobAgnostic # Umbra

--- a/Resources/Prototypes/Loadouts/role_loadouts.yml
+++ b/Resources/Prototypes/Loadouts/role_loadouts.yml
@@ -287,7 +287,7 @@
   - SecurityShoes
   - SecurityGlassesOrHud # CD Addition
   - Trinkets
-  - PersonalItemsHoS # Umbra
+  - PersonalItemsJobAgnostic # Umbra
 
 - type: roleLoadout
   id: JobWarden
@@ -300,7 +300,7 @@
   - SecurityShoes
   - SecurityGlassesOrHud # CD Addition
   - Trinkets
-  - PersonalItemsJobAgnostic # Umbra
+  - PersonalItemsWarden # Umbra
 
 - type: roleLoadout
   id: JobSecurityOfficer

--- a/Resources/Prototypes/_CD/Loadouts/role_loadouts.yml
+++ b/Resources/Prototypes/_CD/Loadouts/role_loadouts.yml
@@ -10,6 +10,7 @@
   - PrivateInvestigatorShoes
   - PrivateInvestigatorGlasses
   - Trinkets
+  - PersonalItemsJobAgnostic # Umbra
 
 # Engineering
 - type: roleLoadout
@@ -21,6 +22,7 @@
   - StationEngineerOuterClothing
   - StationEngineerShoes
   - Trinkets
+  - PersonalItemsJobAgnostic # Umbra
 
 # Science
 - type: roleLoadout
@@ -34,6 +36,7 @@
   - ScientistGloves
   - ScientistShoes
   - Trinkets
+  - PersonalItemsJobAgnostic # Umbra
 
 # Security
 - type: roleLoadout
@@ -47,6 +50,7 @@
   - SecurityBelt
   - SecurityGlassesOrHud
   - Trinkets
+  - PersonalItemsJobAgnostic # Umbra
 
 # Medical
 - type: roleLoadout
@@ -60,6 +64,7 @@
   - SeniorPhysicianOuterClothing
   - MedicalShoes
   - Trinkets
+  - PersonalItemsJobAgnostic # Umbra
 
 # Wildcards
 - type: roleLoadout

--- a/Resources/Prototypes/_Umbra/Entities/Clothing/Masks/masks.yml
+++ b/Resources/Prototypes/_Umbra/Entities/Clothing/Masks/masks.yml
@@ -1,3 +1,4 @@
+# Player: KittenColony - Character: Welds-The-Pipes
 - type: entity
   parent: ClothingMaskBase
   id: ClothingNeckChewtoy

--- a/Resources/Prototypes/_Umbra/Loadouts/Miscellaneous/personal_items.yml
+++ b/Resources/Prototypes/_Umbra/Loadouts/Miscellaneous/personal_items.yml
@@ -110,6 +110,20 @@
     back:
     - ClothingEyesReadingGlasses
 
+# Welds' synthetic chew fidget
+- type: loadout
+  id: ClothingNeckChewtoy
+  equipment: ClothingNeckChewtoy
+  effects:
+  - !type:PersonalItemLoadoutEffect
+    character: Welds-The-Pipes
+
+- type: startingGear
+  id: ClothingNeckChewtoy
+  storage:
+    back:
+    - ClothingNeckChewtoy
+
 # Wipes' friend medal
 - type: loadout
   id: ClothingNeckWipesFriendMedal

--- a/Resources/Prototypes/_Umbra/Loadouts/Miscellaneous/personal_items.yml
+++ b/Resources/Prototypes/_Umbra/Loadouts/Miscellaneous/personal_items.yml
@@ -1,0 +1,139 @@
+# Deeja's artifact necklace
+- type: loadout
+  id: ClothingNeckArtifactNecklace
+  equipment: ClothingNeckArtifactNecklace
+  effects:
+  - !type:PersonalItemLoadoutEffect
+    character: Deeja-Wujeeta
+
+- type: startingGear
+  id: ClothingNeckArtifactNecklace
+  storage:
+    back:
+    - ClothingNeckArtifactNecklace
+
+# Frosty winter coat
+- type: loadout
+  id: FrostCoat
+  equipment: FrostCoat
+  effects:
+  - !type:PersonalItemLoadoutEffect
+    character: Frostbite-Drago
+
+- type: startingGear
+  id: FrostCoat
+  storage:
+    back:
+    - FrostCoat
+
+# John's Flippo
+- type: loadout
+  id: BozelliLighter
+  equipment: BozelliLighter
+  effects:
+  - !type:PersonalItemLoadoutEffect
+    character: John Bozelli
+
+- type: startingGear
+  id: BozelliLighter
+  storage:
+    back:
+    - BozelliLighter
+
+# Loops' bell collar
+- type: loadout
+  id: ClothingNeckLoopsBellCollar
+  equipment: ClothingNeckLoopsBellCollar
+  effects:
+  - !type:PersonalItemLoadoutEffect
+    character: Loops-the-Horns
+
+- type: startingGear
+  id: ClothingNeckLoopsBellCollar
+  storage:
+    back:
+    - ClothingNeckLoopsBellCollar
+
+# maple moondancer plushie
+- type: loadout
+  id: PlushieMaple
+  equipment: PlushieMaple
+  effects:
+  - !type:PersonalItemLoadoutEffect
+    character: Nashira-Najma
+
+- type: startingGear
+  id: PlushieMaple
+  storage:
+    back:
+    - PlushieMaple
+
+# Miles' flower braid
+- type: loadout
+  id: ClothingHeadHatFlowerBraidGeorgia
+  equipment: ClothingHeadHatFlowerBraidGeorgia
+  effects:
+  - !type:PersonalItemLoadoutEffect
+    character: Georgia A Miles
+
+- type: startingGear
+  id: ClothingHeadHatFlowerBraidGeorgia
+  storage:
+    back:
+    - ClothingHeadHatFlowerBraidGeorgia
+
+# moonlit coat
+- type: loadout
+  id: PersonalItemClothingOuterCoatMoonlitHoS
+  equipment: PersonalItemClothingOuterCoatMoonlitHoS
+  effects:
+  - !type:PersonalItemLoadoutEffect
+    character: "Aur'sai"
+
+- type: startingGear
+  id: PersonalItemClothingOuterCoatMoonlitHoS
+  storage:
+    back:
+    - PersonalItemClothingOuterCoatMoonlitHoS
+
+# moonlit shoulder holster
+- type: loadout
+  id: ClothingBeltMoonlitHolster
+  equipment: ClothingBeltMoonlitHolster
+  effects:
+  - !type:PersonalItemLoadoutEffect
+    character: "Aur'sai"
+
+- type: startingGear
+  id: ClothingBeltMoonlitHolster
+  storage:
+    back:
+    - ClothingBeltMoonlitHolster
+
+# Reading's reading glasses
+- type: loadout
+  id: ClothingEyesReadingGlasses
+  equipment: ClothingEyesReadingGlasses
+  effects:
+  - !type:PersonalItemLoadoutEffect
+    character: Really-Likes-Reading
+
+- type: startingGear
+  id: ClothingEyesReadingGlasses
+  storage:
+    back:
+    - ClothingEyesReadingGlasses
+
+# Wipes' friend medal
+- type: loadout
+  id: ClothingNeckWipesFriendMedal
+  equipment: ClothingNeckWipesFriendMedal
+  effects:
+  - !type:PersonalItemLoadoutEffect
+    character: Wipes-the-Floor
+
+- type: startingGear
+  id: ClothingNeckWipesFriendMedal
+  storage:
+    back:
+    - ClothingNeckWipesFriendMedal

--- a/Resources/Prototypes/_Umbra/Loadouts/Miscellaneous/personal_items.yml
+++ b/Resources/Prototypes/_Umbra/Loadouts/Miscellaneous/personal_items.yml
@@ -26,6 +26,20 @@
     back:
     - FrostCoat
 
+# Jalopy's reinforced raincoat
+- type: loadout
+  id: ClothingOuterCoatReinforcedRaincoat
+  equipment: ClothingOuterCoatReinforcedRaincoat
+  effects:
+  - !type:PersonalItemLoadoutEffect
+    character: Jalopy Oldman
+
+- type: startingGear
+  id: ClothingOuterCoatReinforcedRaincoat
+  storage:
+    back:
+    - ClothingOuterCoatReinforcedRaincoat
+
 # John's Flippo
 - type: loadout
   id: BozelliLighter
@@ -82,34 +96,6 @@
     back:
     - ClothingHeadHatFlowerBraidGeorgia
 
-# moonlit coat
-- type: loadout
-  id: PersonalItemClothingOuterCoatMoonlitHoS
-  equipment: PersonalItemClothingOuterCoatMoonlitHoS
-  effects:
-  - !type:PersonalItemLoadoutEffect
-    character: "Aur'sai"
-
-- type: startingGear
-  id: PersonalItemClothingOuterCoatMoonlitHoS
-  storage:
-    back:
-    - PersonalItemClothingOuterCoatMoonlitHoS
-
-# moonlit shoulder holster
-- type: loadout
-  id: ClothingBeltMoonlitHolster
-  equipment: ClothingBeltMoonlitHolster
-  effects:
-  - !type:PersonalItemLoadoutEffect
-    character: "Aur'sai"
-
-- type: startingGear
-  id: ClothingBeltMoonlitHolster
-  storage:
-    back:
-    - ClothingBeltMoonlitHolster
-
 # Reading's reading glasses
 - type: loadout
   id: ClothingEyesReadingGlasses
@@ -137,3 +123,17 @@
   storage:
     back:
     - ClothingNeckWipesFriendMedal
+
+# Yarna's armoured winter coat
+- type: loadout
+  id: ClothingOuterYarnaArmourCoat
+  equipment: ClothingOuterYarnaArmourCoat
+  effects:
+  - !type:PersonalItemLoadoutEffect
+    character: Yarna Crimson
+
+- type: startingGear
+  id: ClothingOuterYarnaArmourCoat
+  storage:
+    back:
+    - ClothingOuterYarnaArmourCoat

--- a/Resources/Prototypes/_Umbra/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/_Umbra/Loadouts/loadout_groups.yml
@@ -1,0 +1,49 @@
+# General job-agnostic items, for when a job has no job-specific personal items
+- type: loadoutGroup
+  id: PersonalItemsJobAgnostic
+  name: loadout-group-personal-items
+  minLimit: 0
+  maxLimit: 2
+  loadouts:
+  - ClothingNeckArtifactNecklace
+  - FrostCoat
+  - BozelliLighter
+  - ClothingNeckLoopsBellCollar
+  - PlushieMaple
+  - ClothingHeadHatFlowerBraidGeorgia
+  - ClothingEyesReadingGlasses
+  - ClothingNeckWipesFriendMedal
+
+# Personal items including those specific to hoS
+- type: loadoutGroup
+  id: PersonalItemsHoS
+  name: loadout-group-personal-items
+  minLimit: 0
+  maxLimit: 2
+  loadouts:
+  - ClothingNeckArtifactNecklace
+  - FrostCoat
+  - BozelliLighter
+  - ClothingNeckLoopsBellCollar
+  - PlushieMaple
+  - ClothingHeadHatFlowerBraidGeorgia
+  - PersonalItemClothingOuterCoatMoonlitHoS
+  - ClothingEyesReadingGlasses
+  - ClothingNeckWipesFriendMedal
+
+# Personal items including those specific to Detective
+- type: loadoutGroup
+  id: PersonalItemsDetective
+  name: loadout-group-personal-items
+  minLimit: 0
+  maxLimit: 2
+  loadouts:
+  - ClothingNeckArtifactNecklace
+  - FrostCoat
+  - BozelliLighter
+  - ClothingNeckLoopsBellCollar
+  - PlushieMaple
+  - ClothingHeadHatFlowerBraidGeorgia
+  - ClothingBeltMoonlitHolster
+  - ClothingEyesReadingGlasses
+  - ClothingNeckWipesFriendMedal

--- a/Resources/Prototypes/_Umbra/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/_Umbra/Loadouts/loadout_groups.yml
@@ -20,6 +20,7 @@
   - PlushieMaple
   - ClothingHeadHatFlowerBraidGeorgia
   - ClothingEyesReadingGlasses
+  - ClothingNeckChewtoy
   - ClothingNeckWipesFriendMedal
 
 # Personal items specialised for Warden
@@ -36,6 +37,7 @@
   - PlushieMaple
   - ClothingHeadHatFlowerBraidGeorgia
   - ClothingEyesReadingGlasses
+  - ClothingNeckChewtoy
   - ClothingNeckWipesFriendMedal
   - ClothingOuterYarnaArmourCoat
 
@@ -54,4 +56,5 @@
   - ClothingHeadHatFlowerBraidGeorgia
   - ClothingEyesReadingGlasses
   - ClothingOuterCoatReinforcedRaincoat
+  - ClothingNeckChewtoy
   - ClothingNeckWipesFriendMedal

--- a/Resources/Prototypes/_Umbra/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/_Umbra/Loadouts/loadout_groups.yml
@@ -1,3 +1,11 @@
+# Items within each group are ordered alphabetically by item name.
+#
+# IF YOU NEED A NEW GROUP:
+#   1. Copy PersonalItemsJobAgnostic.
+#   2. Replace 'JobAgnostic' with the ONE job the group is intended for.
+#   3. Add job-specific loadouts to the group.
+#   4. Replace the job's PersonalItemsJobAgnostic loadout group with the new group.
+
 # General job-agnostic items, for when a job has no job-specific personal items
 - type: loadoutGroup
   id: PersonalItemsJobAgnostic
@@ -14,9 +22,9 @@
   - ClothingEyesReadingGlasses
   - ClothingNeckWipesFriendMedal
 
-# Personal items including those specific to hoS
+# Personal items specialised for Warden
 - type: loadoutGroup
-  id: PersonalItemsHoS
+  id: PersonalItemsWarden
   name: loadout-group-personal-items
   minLimit: 0
   maxLimit: 2
@@ -27,11 +35,11 @@
   - ClothingNeckLoopsBellCollar
   - PlushieMaple
   - ClothingHeadHatFlowerBraidGeorgia
-  - PersonalItemClothingOuterCoatMoonlitHoS
   - ClothingEyesReadingGlasses
   - ClothingNeckWipesFriendMedal
+  - ClothingOuterYarnaArmourCoat
 
-# Personal items including those specific to Detective
+# Personal items specialised for Detective
 - type: loadoutGroup
   id: PersonalItemsDetective
   name: loadout-group-personal-items
@@ -44,6 +52,6 @@
   - ClothingNeckLoopsBellCollar
   - PlushieMaple
   - ClothingHeadHatFlowerBraidGeorgia
-  - ClothingBeltMoonlitHolster
   - ClothingEyesReadingGlasses
+  - ClothingOuterCoatReinforcedRaincoat
   - ClothingNeckWipesFriendMedal


### PR DESCRIPTION
## About the PR
Adds personal items as a new category in the loadouts setup.

## Why / Balance
We have a variety of personal items, which currently can't be selected by their rightful owners in any way. I understand most sessions start with a flurry of ahelps along the lines of "hey, can I have item X?". Now that loadouts are available, we can add personal items to the loadout setup. With this implementation, personal items are locked based on the character name (exact match, case-insensitive).

## Technical details
This PR touches C# in order to accomplish the following:
- Add a new `LoadoutEffect` named `PersonalItemLoadoutEffect`, responsible for checking whether an item is allowed to be selected. Loadout effects are usually used to restrict items by job playtime, but here we use it to restrict items by character name.
- Rather unfortunately, with upstream's implementation, there is *no way* to get the character name from inside `LoadoutEffect.Validate()`. I had to go and add an `ICharacterProfile` parameter, and update every single place `Validate()` is called, which turned out to be a bigger change than I would have liked.

YAML changes amount to:
- Add `loadout`s and `startingGear` for all personal items currently in Umbra.
- Add three new `loadoutGroup`s: `PersonalItemsJobAgnostic` contains all unrestricted personal items, `PersonalItemsHoS` for the Head of Security (includes job-agnostic items and "moonlit coat"), and `PersonalItemsDetective` for the Detective (includes job-agnostic items and "moonlit holster")
- Add the new loadout groups to every job, including those from CD, except Prisoner. As far as I can tell, there is no way to add loadout groups outside of modifying the `roleLoadout` directly.

~~TODO: Probably make the character name matcher case-insensitive.~~ Done.

## Media
Janitor loadout for Wipes-the-Floor:
![image](https://github.com/Sector-Umbra/Sector-Umbra/assets/30327355/59560d3c-ef6e-4bf4-940f-a0d703c93406)

Librarian loadout for Really-Likes-Reading:
![image](https://github.com/Sector-Umbra/Sector-Umbra/assets/30327355/65664bf2-14c1-47c0-98d5-a13332ae3e72)
Note the tooltip that explains why the Maple Moondancer plushie is unavailable.

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
I sure hope not. But future upstream changes to loadouts will almost certainly break our code here.

**Changelog**
:cl:
- add: Personal items can now be selected from the loadout screen. No need to ahelp anymore!