### PR TITLE
Give admin PDA a universal access configurator

### DIFF
--- a/Content.Shared/Access/Components/AccessOverriderComponent.cs
+++ b/Content.Shared/Access/Components/AccessOverriderComponent.cs
@@ -16,6 +16,10 @@ public sealed partial class AccessOverriderComponent : Component
     [DataField]
     public ItemSlot PrivilegedIdSlot = new();
 
+    // Umbra: Allow admin PDA to configure access
+    [DataField]
+    public bool RequiresPrivilegedId = true;
+
     [ViewVariables(VVAccess.ReadWrite)]
     [DataField]
     public SoundSpecifier? DenialSound;

--- a/Resources/Prototypes/Entities/Objects/Devices/pda.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/pda.yml
@@ -672,6 +672,69 @@
       - NotekeeperCartridge
       - NewsReaderCartridge
       - LogProbeCartridge
+  # Begin Umbra: Allow admin PDA to modify access
+  - type: AccessOverrider
+    accessLevels:
+    - Armory
+    - Atmospherics
+    - Bar
+    - Brig
+    - Detective
+    - Captain
+    - Cargo
+    - Chapel
+    - Chemistry
+    - ChiefEngineer
+    - ChiefMedicalOfficer
+    - Command
+    - Engineering
+    - External
+    - HeadOfPersonnel
+    - HeadOfSecurity
+    - Hydroponics
+    - Janitor
+    - Kitchen
+    - Lawyer
+    - Maintenance
+    - Medical
+    - Quartermaster
+    - Research
+    - ResearchDirector
+    - Salvage
+    - Security
+    - Service
+    - Theatre
+    - CentralCommand
+    - NuclearOperative
+    - SyndicateAgent
+    requiresPrivilegedId: false
+    privilegedIdSlot: # Not actually required, but behaves better when present
+      name: id-card-console-privileged-id
+      ejectSound: /Audio/Machines/id_swipe.ogg
+      insertSound: /Audio/Weapons/Guns/MagIn/batrifle_magin.ogg
+      ejectOnBreak: true
+      swap: false
+      whitelist:
+        components:
+        - IdCard
+    denialSound:
+      path: /Audio/Machines/custom_deny.ogg
+    doAfter: 0.1
+  - type: UserInterface
+    interfaces:
+      enum.PdaUiKey.Key:
+        type: PdaBoundUserInterface
+      enum.StoreUiKey.Key:
+        type: StoreBoundUserInterface
+      enum.RingerUiKey.Key:
+        type: RingerBoundUserInterface
+      enum.InstrumentUiKey.Key:
+        type: InstrumentBoundUserInterface
+      enum.HealthAnalyzerUiKey.Key:
+        type: HealthAnalyzerBoundUserInterface
+      enum.AccessOverriderUiKey.Key: # New compared to BasePDA
+        type: AccessOverriderBoundUserInterface
+  # End Umbra
 
 - type: entity
   parent: CentcomPDA


### PR DESCRIPTION
## About the PR
Add a universal access configurator to the Admin PDA.

## Why / Balance
Requested by @TsjipTsjip. Makes it way easier to configure door access for admin events and stuff. The admin PDA also lets you set Syndicate Agent, Nuclear Operative and Central Command access, which a normal access config does not.

## Technical details
* Add a new field, `AccessOverriderComponent.RequiresPrivilegedId`. If false, ID checks are bypassed: you can set any privilege that the access configurator is configured to configure. Configuration. Defaults to `true` so old behaviour is retained where required.
* Add checks for `RequiresPrivilegedId` where necessary.
* And of course add the `AccessOverrider` component to the admin PDA, along with the access config UI.

It may be easier to view the diff with whitespace changes suppressed.

## Media
https://github.com/Sector-Umbra/Sector-Umbra/assets/30327355/9c53943a-4caa-4f30-b637-89be24a4b58d

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
Yesn't :)

**Changelog**
Nuh-uh!