### PR TITLE
Add Toolshed commands `replays:enable` and `replays:disable`

### DIFF
--- a/Content.Server/_Umbra/Administration/Toolshed/ReplaysCommand.cs
+++ b/Content.Server/_Umbra/Administration/Toolshed/ReplaysCommand.cs
@@ -1,0 +1,26 @@
+using Content.Shared.Administration;
+using Content.Shared.CCVar;
+using Robust.Shared.Configuration;
+using Robust.Shared.Toolshed;
+
+namespace Content.Server.Administration.Toolshed;
+
+[ToolshedCommand, AdminCommand(AdminFlags.Admin)]
+public sealed class ReplaysCommand : ToolshedCommand
+{
+    [Dependency] private readonly IConfigurationManager _cfg = default!;
+
+    [CommandImplementation("enable")]
+    public void Enable([CommandInvocationContext] IInvocationContext ctx)
+    {
+        _cfg.SetCVar(CCVars.ReplayAutoRecord, true);
+        ctx.WriteLine("Replays will now be recorded");
+    }
+
+    [CommandImplementation("disable")]
+    public void Disable([CommandInvocationContext] IInvocationContext ctx)
+    {
+        _cfg.SetCVar(CCVars.ReplayAutoRecord, false);
+        ctx.WriteLine("Replays will no longer be recorded");
+    }
+}

--- a/Resources/Locale/en-US/_Umbra/commands/replays-command.ftl
+++ b/Resources/Locale/en-US/_Umbra/commands/replays-command.ftl
@@ -1,0 +1,2 @@
+command-description-replays-enable = Turns on automatic replay recording, starting next round. Will NOT start recording the current round.
+command-description-replays-disable = Turns off automatic reply recording. Will NOT stop recording the current round.


### PR DESCRIPTION
## About the PR
Adds two new commands for controlling the CVar `replay.auto_record`:

* `replays:enable`
* `replays:disable`

## Why / Balance
These commands allow regular admins (with `ADMIN` permissions) to start and stop replays before and after a round, respectively. Other commands related to replays, such as `replay_recording_start`, require `HOST` permissions. Reconfiguring the server is also a non-starter as access to the server config file is strictly limited.

## Technical details
* New Toolshed command: `ReplaysCommand`. The implementation should be self-explanatory.
* New Fluent translation strings for the command description.

### How to test
* Ensure your local server has `replay.auto_record` set to _false_ (this is the default value).
* Before round start, run `> replays:enable` (with the `>`)
* Run a short round. End it normally; don't `golobby` or anything else that might interfere with the replay recording.
* Ensure a replay exists.
* Run `> replays:disable` (with the `>`)

## Media
![image](https://github.com/Sector-Umbra/Sector-Umbra/assets/30327355/f85455b6-fca3-4fd2-9e7b-37f5ebfc811a)

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
None, if I've done it right!

**Changelog**
N/A, but I expect the admin pre-round checklist will be updated