### PR TITLE
Add CVar to disable the shuttle calling the round end timer upon arrival.

### DIFF
--- a/Content.Server/Shuttles/Systems/EmergencyShuttleSystem.Console.cs
+++ b/Content.Server/Shuttles/Systems/EmergencyShuttleSystem.Console.cs
@@ -220,7 +220,7 @@ public sealed partial class EmergencyShuttleSystem
             ShuttlesLeft = true;
             _chatSystem.DispatchGlobalAnnouncement(Loc.GetString("emergency-shuttle-left", ("transitTime", $"{TransitTime:0}")));
 
-            if (_configManager.GetCVar(CCVars.CallRoundEndWithEmergencyShuttle)) // Umbra: Added config option to disable the round end timer starting when the shuttle leaves
+            if (_configManager.GetCVar(CCVars.EnableEndOfRoundTimer)) // Umbra: Added config option to disable the round end timer starting when the shuttle leaves
             {
                 Timer.Spawn((int) (TransitTime * 1000) + _bufferTime.Milliseconds, () => _roundEnd.EndRound(), _roundEndCancelToken?.Token ?? default);
             }

--- a/Content.Server/Shuttles/Systems/EmergencyShuttleSystem.Console.cs
+++ b/Content.Server/Shuttles/Systems/EmergencyShuttleSystem.Console.cs
@@ -220,7 +220,10 @@ public sealed partial class EmergencyShuttleSystem
             ShuttlesLeft = true;
             _chatSystem.DispatchGlobalAnnouncement(Loc.GetString("emergency-shuttle-left", ("transitTime", $"{TransitTime:0}")));
 
-            Timer.Spawn((int) (TransitTime * 1000) + _bufferTime.Milliseconds, () => _roundEnd.EndRound(), _roundEndCancelToken?.Token ?? default);
+            if (_configManager.GetCVar(CCVars.CallRoundEndWithEmergencyShuttle)) // Umbra: Added config option to disable the round end timer starting when the shuttle leaves
+            {
+                Timer.Spawn((int) (TransitTime * 1000) + _bufferTime.Milliseconds, () => _roundEnd.EndRound(), _roundEndCancelToken?.Token ?? default);
+            }
         }
 
         // All the others.

--- a/Content.Server/_Umbra/Administration/Toolshed/RoundEndShuttleCommand.cs
+++ b/Content.Server/_Umbra/Administration/Toolshed/RoundEndShuttleCommand.cs
@@ -13,14 +13,14 @@ public sealed class RoundEndShuttleCommand : ToolshedCommand
     [CommandImplementation("enable")]
     public void Enable([CommandInvocationContext] IInvocationContext ctx)
     {
-        _cfg.SetCVar(CCVars.CallRoundEndWithEmergencyShuttle, true);
+        _cfg.SetCVar(CCVars.EnableEndOfRoundTimer, true);
         ctx.WriteLine("The round end timer will now start upon shuttle landing.");
     }
 
     [CommandImplementation("disable")]
     public void Disable([CommandInvocationContext] IInvocationContext ctx)
     {
-        _cfg.SetCVar(CCVars.CallRoundEndWithEmergencyShuttle, false);
+        _cfg.SetCVar(CCVars.EnableEndOfRoundTimer, false);
         ctx.WriteLine("The round end timer will no longer start upon shuttle landing.");
     }
 }

--- a/Content.Server/_Umbra/Administration/Toolshed/RoundEndShuttleCommand.cs
+++ b/Content.Server/_Umbra/Administration/Toolshed/RoundEndShuttleCommand.cs
@@ -1,0 +1,26 @@
+﻿using Content.Shared.Administration;
+using Content.Shared.CCVar;
+using Robust.Shared.Configuration;
+using Robust.Shared.Toolshed;
+
+namespace Content.Server.Administration.Toolshed;
+
+[ToolshedCommand, AdminCommand(AdminFlags.Admin)]
+public sealed class RoundEndShuttleCommand : ToolshedCommand
+{
+    [Dependency] private readonly IConfigurationManager _cfg = default!;
+
+    [CommandImplementation("enable")]
+    public void Enable([CommandInvocationContext] IInvocationContext ctx)
+    {
+        _cfg.SetCVar(CCVars.CallRoundEndWithEmergencyShuttle, true);
+        ctx.WriteLine("The round end timer will now start upon shuttle landing.");
+    }
+
+    [CommandImplementation("disable")]
+    public void Disable([CommandInvocationContext] IInvocationContext ctx)
+    {
+        _cfg.SetCVar(CCVars.CallRoundEndWithEmergencyShuttle, false);
+        ctx.WriteLine("The round end timer will no longer start upon shuttle landing.");
+    }
+}

--- a/Content.Server/_Umbra/Administration/Toolshed/ShuttleRoundRestartTimerCommand.cs
+++ b/Content.Server/_Umbra/Administration/Toolshed/ShuttleRoundRestartTimerCommand.cs
@@ -6,7 +6,7 @@ using Robust.Shared.Toolshed;
 namespace Content.Server.Administration.Toolshed;
 
 [ToolshedCommand, AdminCommand(AdminFlags.Admin)]
-public sealed class RoundEndShuttleCommand : ToolshedCommand
+public sealed class ShuttleRoundRestartTimerCommand : ToolshedCommand
 {
     [Dependency] private readonly IConfigurationManager _cfg = default!;
 

--- a/Content.Shared/CCVar/CCVars.cs
+++ b/Content.Shared/CCVar/CCVars.cs
@@ -1590,11 +1590,12 @@ namespace Content.Shared.CCVar
         public static readonly CVarDef<int> EmergencyShuttleAutoCallExtensionTime =
             CVarDef.Create("shuttle.auto_call_extension_time", 45, CVar.SERVERONLY);
 
+        // Sector Umbra:
         /// <summary>
         ///     Whether the round should end timer should start automatically when the shuttle lands at Central Command.
         /// </summary>
-        public static readonly CVarDef<bool> CallRoundEndWithEmergencyShuttle =
-            CVarDef.Create("shuttle.call_round_end_with_emergency_shuttle", true, CVar.SERVERONLY);
+        public static readonly CVarDef<bool> EnableEndOfRoundTimer =
+            CVarDef.Create("shuttle.enable_end_of_round_timer", true, CVar.SERVERONLY);
 
         /*
          * Crew Manifests

--- a/Content.Shared/CCVar/CCVars.cs
+++ b/Content.Shared/CCVar/CCVars.cs
@@ -1590,6 +1590,12 @@ namespace Content.Shared.CCVar
         public static readonly CVarDef<int> EmergencyShuttleAutoCallExtensionTime =
             CVarDef.Create("shuttle.auto_call_extension_time", 45, CVar.SERVERONLY);
 
+        /// <summary>
+        ///     Whether the round should end timer should start automatically when the shuttle lands at Central Command.
+        /// </summary>
+        public static readonly CVarDef<bool> CallRoundEndWithEmergencyShuttle =
+            CVarDef.Create("shuttle.call_round_end_with_emergency_shuttle", true, CVar.SERVERONLY);
+
         /*
          * Crew Manifests
          */

--- a/Resources/Locale/en-US/_Umbra/commands/round-end-shuttle-command.ftl
+++ b/Resources/Locale/en-US/_Umbra/commands/round-end-shuttle-command.ftl
@@ -1,2 +1,2 @@
-﻿command-description-roundendshuttle-enable = Turns the round end timer on once the shuttle lands. This will not have an affect if the shuttle already launched.
-command-description-roundendshuttle-disable = Turns the round end timer off once the shuttle lands. This will not have an affect if the shuttle already launched.
+﻿command-description-shuttleroundrestarttimer-enable = Turns on the automatic round restart timer. This will not have an effect if the shuttle has already left the station.
+command-description-shuttleroundrestarttimer-disable = Turns off the automatic round restart timer. This will not have an effect if the shuttle has already left the station.

--- a/Resources/Locale/en-US/_Umbra/commands/round-end-shuttle-command.ftl
+++ b/Resources/Locale/en-US/_Umbra/commands/round-end-shuttle-command.ftl
@@ -1,0 +1,2 @@
+﻿command-description-roundendshuttle-enable = Turns the round end timer on once the shuttle lands. This will not have an affect if the shuttle already launched.
+command-description-roundendshuttle-disable = Turns the round end timer off once the shuttle lands. This will not have an affect if the shuttle already launched.


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Adds a CVar that disables the shuttle calling the 2 minute round end timer.
## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Makes it easier to avoid early round ends via miscommunication. 

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Adds a new CVar, a boolean, which is checked when the shuttle enters FTL. If its true, the timer is started and once the shuttle lands, the 2 minutes (or whatever you have set it to) start.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase
![image](https://github.com/Sector-Umbra/Sector-Umbra/assets/63975668/94ad7b27-3e8e-4fc7-957d-5d40a7eef6cc)

![image](https://github.com/Sector-Umbra/Sector-Umbra/assets/63975668/111cc863-dd93-487e-9a20-7cd696a49565)
