### PR TITLE
Add a helpful comment for personal item loadouts

### DIFF
--- a/Resources/Prototypes/_Umbra/Loadouts/Miscellaneous/personal_items.yml
+++ b/Resources/Prototypes/_Umbra/Loadouts/Miscellaneous/personal_items.yml
@@ -1,3 +1,17 @@
+# TO ADD A NEW PERSONAL ITEM LOADOUT, you MUST do the following:
+#
+# 1. Create a LOADOUT (type: loadout) with a PersonalItemLoadoutEffect
+#    that refers to your character. Punctuation MUST match EXACTLY.
+#    ID: same as the personal item entity.
+# 2. Create a STARTING GEAR (type: startingGear) that equips the item.
+#    If the item fits in a backpack, use the `back:` slot. Otherwise,
+#    use the `inhand:` slot.
+#    ID: same as the personal item entity.
+# 3. One loadout and one starting gear per item.
+# 4. One item per starting gear.
+# 5. Add the loadout to every applicable LOADOUT GROUP in loadout_groups.yml
+#    (in the parent folder of this file).
+
 #Borgs' Beret
 - type: loadout
   id: ClothingHeadBorgsBeret


### PR DESCRIPTION
## About the PR
Adds a helpful comment in `personal_items.yml`, for those who wish to add a personal item to the loadout system.

## Why / Balance
Loadouts are kind of a confusing mess of indirection. To add a personal item, you have to create a `startingGear` that equips the item, a `loadout` that equips the starting gear, _and_ add the loadout to a `loadoutGroup` (or several). Since loadout groups are defined in a separate file, it's easy to miss. In fact, I've observed several of our players thinking it's enough to add the personal item to personal_items.yml. (Why wouldn't it be? Look at the name of the file!) The comment is intended to reduce the occurrence of "why isn't my item showing up?!".

## Technical details
It's literally just a comment.

## Media
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
No.

**Changelog**
N/A