### PR TITLE
Remove QSI from Tech Tree

### DIFF
--- a/Resources/Maps/Shuttles/ShuttleEvent/honki.yml
+++ b/Resources/Maps/Shuttles/ShuttleEvent/honki.yml
@@ -969,23 +969,22 @@ entities:
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
-# Umbra change, commented out due to QSI bugs
-# - proto: DeviceQuantumSpinInverter
-#   entities:
-#   - uid: 25
-#     components:
-#     - type: Transform
-#       parent: 21
-#     - type: Physics
-#       canCollide: False
-#     - type: InsideEntityStorage
-#   - uid: 30
-#     components:
-#     - type: Transform
-#       parent: 26
-#     - type: Physics
-#       canCollide: False
-#     - type: InsideEntityStorage
+- proto: DeviceQuantumSpinInverter
+  entities:
+  - uid: 25
+    components:
+    - type: Transform
+      parent: 21
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 30
+    components:
+    - type: Transform
+      parent: 26
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
 - proto: EmergencyFunnyOxygenTankFilled
   entities:
   - uid: 98

--- a/Resources/Maps/Shuttles/ShuttleEvent/honki.yml
+++ b/Resources/Maps/Shuttles/ShuttleEvent/honki.yml
@@ -854,7 +854,7 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          # - 25 Umbra change, QSI commented out
+          - 25
           - 23
           - 22
           - 24
@@ -896,7 +896,7 @@ entities:
           - 315
           - 27
           - 28
-          # - 30 Umbra change, QSI commented out
+          - 30
         paper_label: !type:ContainerSlot
           showEnts: False
           occludes: True

--- a/Resources/Maps/Shuttles/ShuttleEvent/honki.yml
+++ b/Resources/Maps/Shuttles/ShuttleEvent/honki.yml
@@ -854,7 +854,7 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 25
+          # - 25 Umbra change, QSI commented out
           - 23
           - 22
           - 24
@@ -896,7 +896,7 @@ entities:
           - 315
           - 27
           - 28
-          - 30
+          # - 30 Umbra change, QSI commented out
         paper_label: !type:ContainerSlot
           showEnts: False
           occludes: True
@@ -969,22 +969,23 @@ entities:
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
-- proto: DeviceQuantumSpinInverter
-  entities:
-  - uid: 25
-    components:
-    - type: Transform
-      parent: 21
-    - type: Physics
-      canCollide: False
-    - type: InsideEntityStorage
-  - uid: 30
-    components:
-    - type: Transform
-      parent: 26
-    - type: Physics
-      canCollide: False
-    - type: InsideEntityStorage
+# Umbra change, commented out due to QSI bugs
+# - proto: DeviceQuantumSpinInverter
+#   entities:
+#   - uid: 25
+#     components:
+#     - type: Transform
+#       parent: 21
+#     - type: Physics
+#       canCollide: False
+#     - type: InsideEntityStorage
+#   - uid: 30
+#     components:
+#     - type: Transform
+#       parent: 26
+#     - type: Physics
+#       canCollide: False
+#     - type: InsideEntityStorage
 - proto: EmergencyFunnyOxygenTankFilled
   entities:
   - uid: 98

--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -333,7 +333,7 @@
       - FauxTileAstroIce
       - FauxTileAstroSnow
       - OreBagOfHolding
-      - DeviceQuantumSpinInverter
+#     - DeviceQuantumSpinInverter # Umbra change, commented out due to QSI bugs
   - type: EmagLatheRecipes
     emagDynamicRecipes:
       - BoxBeanbag

--- a/Resources/Prototypes/Recipes/Lathes/devices.yml
+++ b/Resources/Prototypes/Recipes/Lathes/devices.yml
@@ -193,14 +193,15 @@
     Glass: 400
     Silver: 200
 
-- type: latheRecipe
-  id: DeviceQuantumSpinInverter
-  result: DeviceQuantumSpinInverter
-  completetime: 5
-  materials:
-    Steel: 700
-    Glass: 100
-    Uranium: 100
+# Umbra change, commented out due to QSI bugs
+# - type: latheRecipe
+#   id: DeviceQuantumSpinInverter
+#   result: DeviceQuantumSpinInverter
+#   completetime: 5
+#   materials:
+#     Steel: 700
+#     Glass: 100
+#     Uranium: 100
 
 - type: latheRecipe
   id: WeaponProtoKineticAccelerator

--- a/Resources/Prototypes/Research/experimental.yml
+++ b/Resources/Prototypes/Research/experimental.yml
@@ -140,14 +140,17 @@
     - WeaponForceGun
     - WeaponTetherGun
 
-- type: technology
-  id: QuantumLeaping
-  name: research-technology-quantum-leaping
-  icon:
-    sprite: Objects/Devices/swapper.rsi
-    state: icon
-  discipline: Experimental
-  tier: 3
-  cost: 10000
-  recipeUnlocks:
-  - DeviceQuantumSpinInverter
+# Umbra change
+# Commented out due to QSIs throwing people into nullspace
+# Can be returned once QSIs aren't so buggy 
+# - type: technology
+#   id: QuantumLeaping
+#   name: research-technology-quantum-leaping
+#   icon:
+#     sprite: Objects/Devices/swapper.rsi
+#     state: icon
+#   discipline: Experimental
+#   tier: 3
+#   cost: 10000
+#   recipeUnlocks:
+#   - DeviceQuantumSpinInverter


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->

Removes the Quantum Spin Inverter from the Science tech tree, and the honki shuttle. It's only available via admin entity spawn menu.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->

Requested by Game Masters due to bugs.
Note that this makes the Experimental T3 techs only have one option. 

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

This only comments out the code for where the QSI is accessed in the game, not the prototype itself. 

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

- remove: Removed QSI