### PR TITLE
fix the mystery figurine box not having the umbra figurines

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Crates/fun.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/fun.yml
@@ -349,9 +349,9 @@
   components:
   - type: StorageFill
     contents:
-      - id: MysteryFigureBox
+      - id: MysteryFigureBoxUmbra
         amount: 10
-      - id: MysteryFigureBox
+      - id: MysteryFigureBoxUmbra
         amount: 15
         prob: 0.05
 


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Made the mystery figurine crate use the MysteryFigurineBoxUmbra prototype instead of the MysteryFigurineBox prototype.
The Umbra figurines should now be obtainable from the Mystery figurine crate now
## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
The MysteryFigurineBox prototype lacks the umbra figurines.