### PR TITLE
Roundstart Prisoner Tracking Implant

### DIFF
--- a/Resources/Prototypes/_CD/Roles/Jobs/Wildcards/prisoner.yml
+++ b/Resources/Prototypes/_CD/Roles/Jobs/Wildcards/prisoner.yml
@@ -10,6 +10,8 @@
   - !type:NotifyDepartmentSpecial
     notify_text: job-prisoner-sec-notify-text
     radio_channel: Security
+  - !type:AddImplantSpecial #Umbra Change - Prisoners will start with tracking inplants.
+    implants: [ TrackingImplant ] #Umbra Change
 
 - type: startingGear
   id: PrisonerGear


### PR DESCRIPTION
## About the PR
Prisoners will now spawn in with a tracking implant

## Why / Balance
Requested By @luckyshotpictures .

## Technical details
YML. Adds a new special `!type:AddImplantSpecial` to the prisoner role.

## Media
Difficult to properly display, but there it is.
![image](https://github.com/user-attachments/assets/6774aa5f-e77b-440c-8320-36fa523d4f91)

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase
