### PR TITLE
Fix fax notification in admin chat not specifying anything useful

### DIFF
--- a/Content.Server/Fax/FaxConstants.cs
+++ b/Content.Server/Fax/FaxConstants.cs
@@ -21,6 +21,8 @@ public static class FaxConstants
 
     // Data
 
+    public const string FaxSenderName = "fax_sender_actor";
+    public const string FaxSenderMachineName = "fax_sender_machine_name";
     public const string FaxNameData = "fax_data_name";
     public const string FaxPaperNameData = "fax_data_title";
     public const string FaxPaperLabelData = "fax_data_label";

--- a/Content.Server/Fax/FaxConstants.cs
+++ b/Content.Server/Fax/FaxConstants.cs
@@ -21,8 +21,8 @@ public static class FaxConstants
 
     // Data
 
-    public const string FaxSenderActorName = "fax_sender_actor_name"; // Umbra
-    public const string FaxSenderMachineName = "fax_sender_machine_name"; // Umbra
+    public const string FaxSenderActorName = "fax_sender_actor_name"; // Umbra: Add name of who sent the fax
+    public const string FaxSenderMachineName = "fax_sender_machine_name"; // Umbra: Add name of the sending fax machine
     public const string FaxNameData = "fax_data_name";
     public const string FaxPaperNameData = "fax_data_title";
     public const string FaxPaperLabelData = "fax_data_label";

--- a/Content.Server/Fax/FaxConstants.cs
+++ b/Content.Server/Fax/FaxConstants.cs
@@ -21,8 +21,8 @@ public static class FaxConstants
 
     // Data
 
-    public const string FaxSenderName = "fax_sender_actor";
-    public const string FaxSenderMachineName = "fax_sender_machine_name";
+    public const string FaxSenderActorName = "fax_sender_actor_name"; // Umbra
+    public const string FaxSenderMachineName = "fax_sender_machine_name"; // Umbra
     public const string FaxNameData = "fax_data_name";
     public const string FaxPaperNameData = "fax_data_title";
     public const string FaxPaperLabelData = "fax_data_label";

--- a/Content.Server/Fax/FaxSystem.cs
+++ b/Content.Server/Fax/FaxSystem.cs
@@ -621,12 +621,15 @@ public sealed class FaxSystem : EntitySystem
         _adminLogger.Add(LogType.Action, LogImpact.Low, $"\"{component.FaxName}\" {ToPrettyString(uid):tool} printed {ToPrettyString(printed):subject}: {printout.Content}");
     }
 
+    /// <summary>
+    ///     Umbra: Added name of who sent the fax, and the name of the machine that sent the fax.
+    /// </summary>
     private void NotifyAdmins(string? senderName, string? senderMachineName, string? receiverMachineName)
     {
         _chat.SendAdminAnnouncement(Loc.GetString("fax-machine-chat-notify",
-            ("actor", senderName ?? "unknown"),
-            ("source", senderMachineName ?? "unknown"),
-            ("destination", receiverMachineName ?? "unknown")));
+            ("actor", senderName ?? "unknown"), // Umbra: Use name of player who sent it
+            ("source", senderMachineName ?? "unknown"), // Umbra: Use name of fax machine that sent it
+            ("destination", receiverMachineName ?? "unknown"))); // Umbra: Use name of fax machine that received it
         _audioSystem.PlayGlobal("/Audio/Machines/high_tech_confirm.ogg", Filter.Empty().AddPlayers(_adminManager.ActiveAdmins), false, AudioParams.Default.WithVolume(-8f));
     }
 }

--- a/Resources/Locale/en-US/fax/fax.ftl
+++ b/Resources/Locale/en-US/fax/fax.ftl
@@ -23,6 +23,6 @@ fax-machine-ui-paper = Paper:
 fax-machine-ui-paper-inserted = Paper in tray
 fax-machine-ui-paper-not-inserted = No paper
 
-fax-machine-chat-notify = Received new fax message from "{$fax}" fax
+fax-machine-chat-notify = {$actor} faxed from {$source} to {$destination}
 
 fax-machine-printed-paper-name = printed paper

--- a/Resources/Locale/en-US/fax/fax.ftl
+++ b/Resources/Locale/en-US/fax/fax.ftl
@@ -23,6 +23,7 @@ fax-machine-ui-paper = Paper:
 fax-machine-ui-paper-inserted = Paper in tray
 fax-machine-ui-paper-not-inserted = No paper
 
+# Umbra: Replaced message with one that actually shows *who* sent the fax and where *from* as well.
 fax-machine-chat-notify = {$actor} faxed from {$source} to {$destination}
 
 fax-machine-printed-paper-name = printed paper


### PR DESCRIPTION
(cherry picked from commit c117bbad6f12fcd0bbbb48f59e264ad495fb7b0f)

I fixed this over on Echo Station over at https://github.com/echo-station/echo-station/pull/42 and @luckyshotpictures asked me to merge it to Umbra as well!

## About the PR
- Modified FaxSystem to show admins USEFUL information during a round about WHO sent the fax, where FROM and where TO.
  - This still only applies to Fax machines marked as Admin destinations, i.e. the Central Command one and the "!@#@#" one.

## Why / Balance
It was awful before. "Received fax from unknown" does not tell me who sent it or who I should reply to.

## Technical details
- Added two fields to the fax payload that is transmitted via the DeviceNetworkSystem:
  - One containing the name of the sender,
  - One containing the name of the fax machine.
- Using those properties we can now format a useful admin message
- Updated format of admin message (naturally)

## Media

### Before
![353145473-08cc026f-bd94-46c0-9a15-a5d21e5e5d6f](https://github.com/user-attachments/assets/43a9973a-96c6-4253-b4c9-d506728b1ae2)

### After
![image](https://github.com/user-attachments/assets/e53719f7-e009-4377-93ab-ed0de06d2d88)

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
None

**Changelog**

:cl:
- tweak: Admins can now reliably tell who faxed them and where from.
