### PR TITLE
Support multiple personal item owners

### DIFF
--- a/Content.Shared/Preferences/Loadouts/Effects/PersonalItemLoadoutEffect.cs
+++ b/Content.Shared/Preferences/Loadouts/Effects/PersonalItemLoadoutEffect.cs
@@ -14,7 +14,7 @@ namespace Content.Shared.Preferences.Loadouts.Effects;
 public sealed partial class PersonalItemLoadoutEffect : LoadoutEffect
 {
     [DataField("character", required: true)]
-    public string CharacterName = default!;
+    public HashSet<string> CharacterName = default!;
 
     public override bool Validate(
         HumanoidCharacterProfile profile,
@@ -23,8 +23,7 @@ public sealed partial class PersonalItemLoadoutEffect : LoadoutEffect
         IDependencyCollection collection,
         [NotNullWhen(false)] out FormattedMessage? reason)
     {
-        if (profile is HumanoidCharacterProfile humanoid &&
-            humanoid.Name.Equals(CharacterName, StringComparison.InvariantCultureIgnoreCase))
+        if (profile is HumanoidCharacterProfile humanoid && CharacterName.Contains(humanoid.Name))
         {
             reason = null;
             return true;
@@ -32,7 +31,7 @@ public sealed partial class PersonalItemLoadoutEffect : LoadoutEffect
 
         reason = FormattedMessage.FromUnformatted(Loc.GetString(
             "loadout-personal-item-belongs-to",
-            ("character", CharacterName)));
+            ("character", string.Join(", ", CharacterName))));
         return false;
     }
 }

--- a/Resources/Prototypes/_Umbra/Loadouts/Miscellaneous/personal_items.yml
+++ b/Resources/Prototypes/_Umbra/Loadouts/Miscellaneous/personal_items.yml
@@ -18,7 +18,8 @@
   equipment: ClothingHeadBorgsBeret
   effects:
   - !type:PersonalItemLoadoutEffect
-    character: Borgs-the-Brains
+    character:
+    - Borgs-the-Brains
 
 - type: startingGear
   id: ClothingHeadBorgsBeret
@@ -32,7 +33,8 @@
   equipment: ClothingNeckBorgsScarf
   effects:
   - !type:PersonalItemLoadoutEffect
-    character: Borgs-the-Brains
+    character: 
+    - Borgs-the-Brains
 
 - type: startingGear
   id: ClothingNeckBorgsScarf
@@ -46,7 +48,8 @@
   equipment:  ClothingUniformJumpsuitCarpSuit
   effects:
   - !type:PersonalItemLoadoutEffect
-    character: Chance Boulevard
+    character: 
+    - Chance Boulevard
 
 - type: startingGear
   id: ClothingUniformJumpsuitCarpSuit
@@ -60,7 +63,8 @@
   equipment: ClothingNeckArtifactNecklace
   effects:
   - !type:PersonalItemLoadoutEffect
-    character: Deeja-Wujeeta
+    character: 
+    - Deeja-Wujeeta
 
 - type: startingGear
   id: ClothingNeckArtifactNecklace
@@ -74,7 +78,8 @@
   equipment: PlushieJasmi
   effects:
   - !type:PersonalItemLoadoutEffect
-    character: Deeja-Wujeeta
+    character: 
+    - Deeja-Wujeeta
 
 - type: startingGear
   id: PlushieJasmi
@@ -89,7 +94,8 @@
   equipment: PlushieEris
   effects:
   - !type:PersonalItemLoadoutEffect
-    character: Eris Rose
+    character: 
+    - Eris Rose
 
 - type: startingGear
   id: PlushieEris
@@ -103,7 +109,8 @@
   equipment: ClothingHeadsetErisAid
   effects:
   - !type:PersonalItemLoadoutEffect
-    character: Eris Rose
+    character:
+    - Eris Rose
 
 - type: startingGear
   id: ClothingHeadsetErisAid
@@ -117,7 +124,8 @@
   equipment: FrostCoat
   effects:
   - !type:PersonalItemLoadoutEffect
-    character: Frostbite-Drago
+    character: 
+    - Frostbite-Drago
 
 - type: startingGear
   id: FrostCoat
@@ -131,7 +139,8 @@
   equipment: FateseekersGemstone
   effects:
   - !type:PersonalItemLoadoutEffect
-    character: Fateseeker
+    character: 
+    - Fateseeker
 
 - type: startingGear
   id: FateseekersGemstone
@@ -145,7 +154,8 @@
   equipment: ClothingNeckHushPendant
   effects:
   - !type:PersonalItemLoadoutEffect
-    character: Hush Pallister
+    character: 
+    - Hush Pallister
 
 - type: startingGear
   id: ClothingNeckHushPendant
@@ -159,7 +169,8 @@
   equipment: ClothingOuterCoatReinforcedRaincoat
   effects:
   - !type:PersonalItemLoadoutEffect
-    character: Jalopy Oldman
+    character: 
+    - Jalopy Oldman
 
 - type: startingGear
   id: ClothingOuterCoatReinforcedRaincoat
@@ -173,7 +184,8 @@
   equipment: ClothingHeadHatRainbowFlowerJasmi
   effects:
   - !type:PersonalItemLoadoutEffect
-    character: Jasmi-Wujeeta
+    character: 
+    - Jasmi-Wujeeta
 
 - type: startingGear
   id: ClothingHeadHatRainbowFlowerJasmi
@@ -187,7 +199,8 @@
   equipment: PetRockBobby
   effects:
   - !type:PersonalItemLoadoutEffect
-    character: Joetta Beedell
+    character: 
+    - Joetta Beedell
 
 - type: startingGear
   id: PetRockBobby
@@ -201,7 +214,8 @@
   equipment: PlushieDeeja
   effects:
   - !type:PersonalItemLoadoutEffect
-    character: Jasmi-Wujeeta
+    character: 
+    - Jasmi-Wujeeta
 
 - type: startingGear
   id: PlushieDeeja
@@ -215,7 +229,8 @@
   equipment: PlushieJuniper
   effects:
   - !type:PersonalItemLoadoutEffect
-    character: John Armstrong
+    character: 
+    - John Armstrong
 
 - type: startingGear
   id: PlushieJuniper
@@ -229,7 +244,8 @@
   equipment: ClothingNeckLoopsBellCollar
   effects:
   - !type:PersonalItemLoadoutEffect
-    character: Loops-the-Horns
+    character: 
+    - Loops-the-Horns
 
 - type: startingGear
   id: ClothingNeckLoopsBellCollar
@@ -243,7 +259,8 @@
   equipment: ClothingHeadHatFlowerBraidGeorgia
   effects:
   - !type:PersonalItemLoadoutEffect
-    character: Georgia A Miles
+    character: 
+    - Georgia A Miles
 
 - type: startingGear
   id: ClothingHeadHatFlowerBraidGeorgia
@@ -257,7 +274,8 @@
   equipment: PlushieMaple
   effects:
   - !type:PersonalItemLoadoutEffect
-    character: Nashira-Najma
+    character: 
+    - Nashira-Najma
 
 - type: startingGear
   id: PlushieMaple
@@ -271,7 +289,8 @@
   equipment: PlushieOliver
   effects:
   - !type:PersonalItemLoadoutEffect
-    character: Oliver Cambridge
+    character: 
+    - Oliver Cambridge
 
 - type: startingGear
   id: PlushieOliver
@@ -285,7 +304,8 @@
   equipment: ClothingOuterGalaxyCoat
   effects:
   - !type:PersonalItemLoadoutEffect
-    character: Nova Gem
+    character: 
+    - Nova Gem
 
 - type: startingGear
   id: ClothingOuterGalaxyCoat
@@ -299,7 +319,8 @@
   equipment: ClothingEyesReadingGlasses
   effects:
   - !type:PersonalItemLoadoutEffect
-    character: Really-Likes-Reading
+    character: 
+    - Really-Likes-Reading
 
 - type: startingGear
   id: ClothingEyesReadingGlasses
@@ -313,7 +334,8 @@
   equipment: ClothingNeckRyeTie
   effects:
   - !type:PersonalItemLoadoutEffect
-    character: Ryeversi Venusta
+    character: 
+    - Ryeversi Venusta
 
 - type: startingGear
   id: ClothingNeckRyeTie
@@ -327,7 +349,8 @@
   equipment: PlushieVesper
   effects:
   - !type:PersonalItemLoadoutEffect
-    character: Vesper
+    character: 
+    - Vesper
 
 - type: startingGear
   id: PlushieVesper
@@ -341,7 +364,8 @@
   equipment: ClothingNeckChewtoy
   effects:
   - !type:PersonalItemLoadoutEffect
-    character: Welds-The-Pipes
+    character: 
+    - Welds-The-Pipes
 
 - type: startingGear
   id: ClothingNeckChewtoy
@@ -355,7 +379,8 @@
   equipment: ClothingShoesMiscWeldsWalker
   effects:
   - !type:PersonalItemLoadoutEffect
-    character: Welds-The-Pipes
+    character: 
+    - Welds-The-Pipes
 
 - type: startingGear
   id: ClothingShoesMiscWeldsWalker
@@ -369,7 +394,8 @@
   equipment: ClothingNeckWipesFriendMedal
   effects:
   - !type:PersonalItemLoadoutEffect
-    character: Wipes-the-Floor
+    character: 
+    - Wipes-the-Floor
 
 - type: startingGear
   id: ClothingNeckWipesFriendMedal
@@ -383,7 +409,8 @@
   equipment: ClothingOuterYarnaArmourCoat
   effects:
   - !type:PersonalItemLoadoutEffect
-    character: Yarna Crimson
+    character: 
+    - Yarna Crimson
 
 - type: startingGear
   id: ClothingOuterYarnaArmourCoat


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->

Makes personal items support being given to multiple characters.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->

Requested feature. Saves having multiple loadouts.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

Changed the CharacterName string to a hashset and checks if the character name is contained within the hashset. 
All loadouts have been given a little "-" to make 'em hashsets.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

The images below have Jasmi's hairflower given to both Jasmi and Jalopy (this is just an example and not included in the PR).

Image 1: Jalopy having access to the hairflower.
![image](https://github.com/user-attachments/assets/31015dab-02ad-4096-b1c6-5f5f8c76bb80)

Image 2: Description for multi-character items.
![image](https://github.com/user-attachments/assets/7cf3e6e1-8fec-48d6-9422-b46ed16a01a4)


- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up. Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog.
-->
:cl:
- fix: Personal items now support multiple owners.
