### PR TITLE
Disable most unwanted antag roles from autorolling.

### DIFF
--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -21,12 +21,13 @@
     - id: SpiderClownSpawn
     - id: SpiderSpawn
     - id: VentClog
+    - id: ClosetSkeleton # Umbra: Moved from BasicAntagEventsTable
 
 - type: entityTable
   id: BasicAntagEventsTable
   table: !type:AllSelector # we need to pass a list of rules, since rules have further restrictions to consider via StationEventComp
     children:
-    - id: ClosetSkeleton
+    # - id: ClosetSkeleton # Umbra: Moved to BasicCalmEventsTable
     - id: DragonSpawn
     - id: KingRatMigration
     - id: NinjaSpawn
@@ -143,6 +144,8 @@
   - type: StationEvent
     weight: 5
     duration: 1
+    earliestStart: 30 # Umbra: Don't want skeletons earlier than half an hour into the shift.
+    reoccurrenceDelay: 60 # Umbra: Skeletons should be rare.
   - type: RandomEntityStorageSpawnRule
     prototype: MobSkeletonCloset
 

--- a/Resources/Prototypes/GameRules/meteorswarms.yml
+++ b/Resources/Prototypes/GameRules/meteorswarms.yml
@@ -57,12 +57,12 @@
   components:
   - type: GameRule
   - type: BasicStationEventScheduler
-    minimumTimeUntilFirstEvent: 300 # 5 min
+    minimumTimeUntilFirstEvent: 900 # 5 min -> Umbra: 15 minutes
     minMaxEventTiming:
-      min: 750 # 12.5 min
-      max: 930 # 17.5 min
+      min: 1800 # 12.5 min -> Umbra: 30 minutes
+      max: 7200 # 17.5 min -> Umbra: 120 minutes
     scheduledGameRules: !type:NestedSelector
-      tableId: BasicMeteorSwarmEventsTable
+      tableId: MeteorSwarmMildTable # Umbra: Changed from BasicMeteorSwarmEventsTable
 
 - type: entity
   parent: BaseGameRule
@@ -72,8 +72,8 @@
   - type: BasicStationEventScheduler
     minimumTimeUntilFirstEvent: 1200 # 20 min
     minMaxEventTiming:
-      min: 750 # 12.5 min
-      max: 930 # 17.5 min
+      min: 2700 # 12.5 min -> Umbra: 45 minutes
+      max: 10800 # 17.5 min -> Umbra: 180 minutes
     scheduledGameRules: !type:NestedSelector
       tableId: MeteorSwarmMildTable
 

--- a/Resources/Prototypes/GameRules/meteorswarms.yml
+++ b/Resources/Prototypes/GameRules/meteorswarms.yml
@@ -33,7 +33,7 @@
     - id: GameRuleMeteorSwarmMedium
     # - id: GameRuleMeteorSwarmLarge # Umbra/CD: Disable
     - id: GameRuleUristSwarm
-    - id: ImmovableRodSpawn
+    # - id: ImmovableRodSpawn # Umbra: Disable
 
 - type: weightedRandomEntity
   id: MeteorSpawnAsteroidWallTable

--- a/Resources/Prototypes/GameRules/roundstart.yml
+++ b/Resources/Prototypes/GameRules/roundstart.yml
@@ -73,7 +73,7 @@
   parent: BaseGameRule
   id: BaseNukeopsRule
   components:
-  - type: RandomMetadata #this generates the random operation name cuz it's cool. 
+  - type: RandomMetadata #this generates the random operation name cuz it's cool.
     nameSegments:
     - operationPrefix
     - operationSuffix
@@ -269,8 +269,8 @@
     children:
       - !type:NestedSelector
         tableId: BasicCalmEventsTable
-      - !type:NestedSelector
-        tableId: BasicAntagEventsTable
+      # - !type:NestedSelector # Umbra: Disable.
+      #   tableId: BasicAntagEventsTable
       - !type:NestedSelector
         tableId: CargoGiftsTable
 
@@ -306,22 +306,22 @@
   parent: BaseGameRule                  # we can remerge this with the other schedulers, but it will silently fail due to that limitation without a separate scheduler to balance atm.
   components:
   - type: BasicStationEventScheduler
-    minimumTimeUntilFirstEvent: 1200 # 20 mins
+    minimumTimeUntilFirstEvent: 1800 # 20 mins -> Umbra: 30 minutes
     minMaxEventTiming:
-      min: 600 # 10 mins
-      max: 1800 # 30 mins
+      min: 1200 # 10 mins -> Umbra: 20 minutes
+      max: 3600 # 30 mins -> Umbra: 60 minutes
     scheduledGameRules: !type:NestedSelector
       tableId: SpaceTrafficControlTable
 
 - type: entity
-  id: SpaceTrafficControlFriendlyEventScheduler 
-  parent: BaseGameRule                  
+  id: SpaceTrafficControlFriendlyEventScheduler
+  parent: BaseGameRule
   components:
   - type: BasicStationEventScheduler
-    minimumTimeUntilFirstEvent: 1200 # 20 mins
+    minimumTimeUntilFirstEvent: 1800 # 20 mins -> Umbra: 30 minutes
     minMaxEventTiming:
-      min: 600 # 10 mins
-      max: 1800 # 30 mins
+      min: 1200 # 10 mins -> Umbra: 20 minutes
+      max: 3600 # 30 mins -> Umbra: 60 minutes
     scheduledGameRules: !type:NestedSelector
       tableId: UnknownShuttlesFriendlyTable
 


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->

Disables all antag ghostroles from autorolling.

Nerfs STC event schedulers.

Closet skeletons can still spawn (not antags) but only once every hour, starting after half an hour.

Closes #119 .
