### PR TITLE
Fix Changed Owner Names on Personal Items

### DIFF
--- a/Resources/Prototypes/_Umbra/Entities/Objects/Fun/toys.yml
+++ b/Resources/Prototypes/_Umbra/Entities/Objects/Fun/toys.yml
@@ -23,7 +23,7 @@
     state: plushie_vesper
     sprite: _Umbra/Objects/Fun/Toys/plushie_vesper.rsi
 
-# Player: lemonrat - Character: Oliver Cambridge
+# Player: lemonrat - Character: Oliver LaRue
 - type: entity
   parent: PlushieLizard
   id: PlushieOliver

--- a/Resources/Prototypes/_Umbra/Entities/Objects/Fun/toys.yml
+++ b/Resources/Prototypes/_Umbra/Entities/Objects/Fun/toys.yml
@@ -125,12 +125,12 @@
     state: plushie_esther
     sprite: _Umbra/Objects/Fun/Toys/plushie_esther.rsi
 
-# Player: raindrops - Character: Nia Noctis
+# Player: raindrops - Character: Nia Scarlet
 - type: entity
   parent: PlushieMoth
   id: PlushieNia
   name: nia plushie
-  description: A plushie depicting Nia Noctis! It's very fuzzy and soft. There is a very subtle pout on its face...
+  description: A plushie depicting Nia Scarlet! It's very fuzzy and soft. There is a very subtle pout on its face...
   suffix: PersonalItem
   components:
   - type: Sprite

--- a/Resources/Prototypes/_Umbra/Entities/Objects/Misc/Books/michaels_card.yml
+++ b/Resources/Prototypes/_Umbra/Entities/Objects/Misc/Books/michaels_card.yml
@@ -1,4 +1,4 @@
-# Player: AemonTillado - Character: Michael Hands
+# Player: AemonTillado - Character: Michael LaRue
 - type: entity
   name: michael's card
   parent: BookBase

--- a/Resources/Prototypes/_Umbra/Loadouts/Miscellaneous/personal_items.yml
+++ b/Resources/Prototypes/_Umbra/Loadouts/Miscellaneous/personal_items.yml
@@ -242,7 +242,7 @@
   effects:
   - !type:PersonalItemLoadoutEffect
     character:
-    - Nia Noctis
+    - Nia Scarlet
 
 # Oliver's oliver's plushie
 - type: loadout

--- a/Resources/Prototypes/_Umbra/Loadouts/Miscellaneous/personal_items.yml
+++ b/Resources/Prototypes/_Umbra/Loadouts/Miscellaneous/personal_items.yml
@@ -429,7 +429,7 @@
   effects:
   - !type:PersonalItemLoadoutEffect
     character:
-    - Michael Hands
+    - Michael LaRue
 
 #Ardus' Bandana
 - type: loadout

--- a/Resources/Prototypes/_Umbra/Loadouts/Miscellaneous/personal_items.yml
+++ b/Resources/Prototypes/_Umbra/Loadouts/Miscellaneous/personal_items.yml
@@ -253,7 +253,7 @@
   effects:
   - !type:PersonalItemLoadoutEffect
     character:
-    - Oliver Cambridge
+    - Oliver LaRue
 
 # Nova's Jacket
 - type: loadout

--- a/Resources/Textures/_Umbra/Clothing/Hands/Rings/annies_ring.rsi/meta.json
+++ b/Resources/Textures/_Umbra/Clothing/Hands/Rings/annies_ring.rsi/meta.json
@@ -5,7 +5,7 @@
         "y": 32
     },
     "license": "CC-BY-SA-3.0",
-    "copyright": "Made by AemonTillado for SS14.",
+    "copyright": "Made by HexReject and AemonTillado for SS14.",
     "states": [
         {
             "name": "annies_ring"

--- a/Resources/Textures/_Umbra/Clothing/Hands/Rings/michaels_ring.rsi/meta.json
+++ b/Resources/Textures/_Umbra/Clothing/Hands/Rings/michaels_ring.rsi/meta.json
@@ -5,7 +5,7 @@
         "y": 32
     },
     "license": "CC-BY-SA-3.0",
-    "copyright": "Made by AemonTillado for SS14.",
+    "copyright": "Made by HexReject and AemonTillado for SS14.",
     "states": [
         {
             "name": "michaels_ring"


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Changed the owner of Michael's Card personal item to reflect Michael's name change. Also added previously missing copyright credit for HexReject to Michael and Annie's rings, as they were involved in the creation of the final sprites as used in-game.

EDIT: At the request of onenineone, the owner of the Esthers Plushie personal item has been changed to Nia Scarlet (from Nia Noctis) to represent a similar IC name-change. Additionally, at the request of Lemonrat, the owner of the Oliver's Plushie personal item has been changed to Oliver LaRue (from Oliver Cambridge).

## Why / Balance
Michael has changed his name from Hands to LaRue, so his card personal item needs to be accessible to him under his new name.

The original PR for Michael and Annie's rings was missing HexReject's copyright credit (as I accidentally omitted it when copying over the attribution from Michael's card) - the attribution now lists both HexReject and AemonTillado as the creators of the ring sprites.

EDIT: Additional personal item name changes have been added at the request of their owners so as not to bog things down with multiple PRs that are all changing the same thing.

## Technical details
Loadout list entry has been updated such that Michael's card is owned by Michael LaRue, not Michael Hands. The same has been done for Nia Scarlet, and Oliver LaRue. Copyright attributions for the sprites of Michael and Annie's rings have been updated to include HexReject.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- fix: Fixed the loadout ownership of Michael LaRue's card (personal item).
- fix: Fixed missing copyright attribution on Michael and Annie LaRue's rings (personal items).
- fix: Fixed the loadout ownership of Nia Scarlet's Esther Plushie (personal item).
- fix: Fixed the loadout ownership of Oliver LaRue's Plushie (personal item).

