### PR TITLE
AI, re-enable the AI roles for Sector Umbra.

### DIFF
--- a/Resources/Prototypes/Maps/bagel.yml
+++ b/Resources/Prototypes/Maps/bagel.yml
@@ -66,5 +66,5 @@
             Musician: [ 1, 1 ]
             Reporter: [ 2, 2 ]
             #silicon
-            # StationAi: [ 1, 1 ]
+            StationAi: [ 1, 1 ]
             Borg: [ 2, 2 ]

--- a/Resources/Prototypes/Maps/box.yml
+++ b/Resources/Prototypes/Maps/box.yml
@@ -59,6 +59,6 @@
             Mime: [ 1, 1 ]
             Musician: [ 1, 1 ]
             #silicon
-            # StationAi: [ 1, 1 ]
+            StationAi: [ 1, 1 ]
             Borg: [ 2, 2 ]
 

--- a/Resources/Prototypes/Maps/cog.yml
+++ b/Resources/Prototypes/Maps/cog.yml
@@ -28,7 +28,7 @@
             Reporter: [ 2, 2 ]
             Librarian: [ 1, 1 ]
             ServiceWorker: [ 3, 3 ]
-            Zookeeper: [ 1, 1 ] 
+            Zookeeper: [ 1, 1 ]
             #engineering
             ChiefEngineer: [ 1, 1 ]
             AtmosphericTechnician: [ 3, 3 ]
@@ -63,5 +63,5 @@
             Musician: [ 1, 1 ]
             Boxer: [ 2, 2]
             #silicon
-            # StationAi: [ 1, 1 ]
+            StationAi: [ 1, 1 ]
             Borg: [ 3, 3 ]

--- a/Resources/Prototypes/Maps/core.yml
+++ b/Resources/Prototypes/Maps/core.yml
@@ -68,5 +68,5 @@
             Boxer: [ 2, 2 ]
             Reporter: [ 2, 2 ]
             # silicon
-            # StationAi: [ 1, 1 ]
+            StationAi: [ 1, 1 ]
             Borg: [ 2, 2 ]

--- a/Resources/Prototypes/Maps/fland.yml
+++ b/Resources/Prototypes/Maps/fland.yml
@@ -65,5 +65,5 @@
             Mime: [ 1, 1 ]
             Musician: [ 1, 1 ]
             #silicon
-            # StationAi: [ 1, 1 ]
+            StationAi: [ 1, 1 ]
             Borg: [ 2, 2 ]

--- a/Resources/Prototypes/Maps/marathon.yml
+++ b/Resources/Prototypes/Maps/marathon.yml
@@ -64,5 +64,5 @@
             Mime: [ 1, 1 ]
             Musician: [ 1, 1 ]
             #silicon
-            # StationAi: [ 1, 1 ]
+            StationAi: [ 1, 1 ]
             Borg: [ 2, 2 ]

--- a/Resources/Prototypes/Maps/meta.yml
+++ b/Resources/Prototypes/Maps/meta.yml
@@ -59,5 +59,5 @@
             Mime: [ 1, 1 ]
             Musician: [ 1, 1 ]
             #silicon
-            # StationAi: [ 1, 1 ]
+            StationAi: [ 1, 1 ]
             Borg: [ 2, 2 ]

--- a/Resources/Prototypes/Maps/oasis.yml
+++ b/Resources/Prototypes/Maps/oasis.yml
@@ -44,7 +44,7 @@
             ResearchDirector: [ 1, 1 ]
             Scientist: [ 5, 5 ]
             ResearchAssistant: [ 6, 6 ]
-            # StationAi: [ 1, 1 ]
+            StationAi: [ 1, 1 ]
             Borg: [ 2, 2 ]
             #security
             HeadOfSecurity: [ 1, 1 ]

--- a/Resources/Prototypes/Maps/packed.yml
+++ b/Resources/Prototypes/Maps/packed.yml
@@ -62,5 +62,5 @@
             Mime: [ 1, 1 ]
             Musician: [ 1, 1 ]
             #silicon
-            # StationAi: [ 1, 1 ]
+            StationAi: [ 1, 1 ]
             Borg: [ 1, 1 ]


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

Re-enables AI roles so we don't have to do a ghetto AI role assignment every round. Additional rules and SoP's regarding handling of AI are pending.
