### PR TITLE
Self-Execution no longer activates /suicide

### DIFF
--- a/Content.Shared/Execution/SharedExecutionSystem.cs
+++ b/Content.Shared/Execution/SharedExecutionSystem.cs
@@ -206,13 +206,15 @@ public sealed class SharedExecutionSystem : EntitySystem
         var internalMsg = entity.Comp.CompleteInternalMeleeExecutionMessage;
         var externalMsg = entity.Comp.CompleteExternalMeleeExecutionMessage;
 
+        /// <Umbra summary>
+        /// Instead of raising the suicide event on self-execution: Trigger the standard execution instead.
+        /// Uses InternalSelf and ExternalSelf for the execution messages.
+        /// </Umbra summary>
         if (attacker == victim)
         {
-            var suicideEvent = new SuicideEvent(victim);
-            RaiseLocalEvent(victim, suicideEvent);
-
-            var suicideGhostEvent = new SuicideGhostEvent(victim);
-            RaiseLocalEvent(victim, suicideGhostEvent);
+            _melee.AttemptLightAttack(attacker, weapon, meleeWeaponComp, victim);
+            _execution.ShowExecutionInternalPopup(entity.Comp.InternalSelfExecutionMessage, attacker, victim, entity);
+            _execution.ShowExecutionExternalPopup(entity.Comp.ExternalSelfExecutionMessage, attacker, victim, entity);
         }
         else
         {

--- a/Content.Shared/Execution/SharedExecutionSystem.cs
+++ b/Content.Shared/Execution/SharedExecutionSystem.cs
@@ -206,12 +206,14 @@ public sealed class SharedExecutionSystem : EntitySystem
         var internalMsg = entity.Comp.CompleteInternalMeleeExecutionMessage;
         var externalMsg = entity.Comp.CompleteExternalMeleeExecutionMessage;
 
-        /// <Umbra summary>
-        /// Instead of raising the suicide event on self-execution: Trigger the standard execution instead.
-        /// Uses InternalSelf and ExternalSelf for the execution messages.
-        /// </Umbra summary>
         if (attacker == victim)
         {
+            // UMBRA: Instead of raising the suicide event on self-execution: Trigger the standard execution instead. Uses InternalSelf and ExternalSelf for the execution messages.
+            // var suicideEvent = new SuicideEvent(victim);
+            // RaiseLocalEvent(victim, suicideEvent);
+            // var suicideGhostEvent = new SuicideGhostEvent(victim);
+            // RaiseLocalEvent(victim, suicideGhostEvent);
+            
             _melee.AttemptLightAttack(attacker, weapon, meleeWeaponComp, victim);
             _execution.ShowExecutionInternalPopup(entity.Comp.InternalSelfExecutionMessage, attacker, victim, entity);
             _execution.ShowExecutionExternalPopup(entity.Comp.ExternalSelfExecutionMessage, attacker, victim, entity);


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Self-Executions no longer trigger /suicide.

## Why / Balance
Closes #133 .
See #133 .

## Technical details
Redid the if statement checking if the execution was suicide. It now raises the standard execution event and uses the suicide specific popus.

## Media
N/A

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
N/A

**Changelog**
Self-Executions no longer trigger /suicide. If you execute yourself you may still be revived.
