### PR TITLE
Remove brig access from head roles

### DIFF
--- a/Resources/Prototypes/Roles/Jobs/Cargo/quartermaster.yml
+++ b/Resources/Prototypes/Roles/Jobs/Cargo/quartermaster.yml
@@ -18,7 +18,7 @@
   - Maintenance
   - External
   - Command
-  - Brig
+  # - Brig # Umbra - Removed
   - Cryogenics
   special:
   - !type:AddImplantSpecial

--- a/Resources/Prototypes/Roles/Jobs/Engineering/chief_engineer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Engineering/chief_engineer.yml
@@ -18,7 +18,7 @@
   - External
   - ChiefEngineer
   - Atmospherics
-  - Brig
+  # - Brig # Umbra - Removed
   - Cryogenics
   special:
   - !type:AddImplantSpecial

--- a/Resources/Prototypes/Roles/Jobs/Medical/chief_medical_officer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Medical/chief_medical_officer.yml
@@ -19,7 +19,7 @@
   - Maintenance
   - Chemistry
   - ChiefMedicalOfficer
-  - Brig
+  # - Brig # Umbra - Removed
   - Cryogenics
   special:
   - !type:AddImplantSpecial

--- a/Resources/Prototypes/Roles/Jobs/Science/research_director.yml
+++ b/Resources/Prototypes/Roles/Jobs/Science/research_director.yml
@@ -16,7 +16,7 @@
   - Command
   - Maintenance
   - ResearchDirector
-  - Brig
+  # - Brig # Umbra - Removed
   - Cryogenics
   special:
   - !type:AddImplantSpecial


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

Removes brig access from head roles that aren't:
- Captain
- HoP
- HoS

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

Closes #227 . This change is suitable for a HRP environment.