### PR TITLE
Allow ClothingOuterBase (And its children) to use the suitstorageslot again

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/base_clothingouter.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/base_clothingouter.yml
@@ -8,6 +8,7 @@
     - outerClothing
   - type: Sprite
     state: icon
+  - type: AllowSuitStorage #Umbra Change
 
 - type: entity
   abstract: true


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Any clothing that uses ClothingOuterBase, allows use of the suitstorageslot again. (Ex: Labcoats, coats, jackets, etc.)

## Why / Balance
Maintainers and some GMs agreed this would be best. It allows for more RP opportunities and player expression.

## Technical details
Clothingouterbase now has the compontent to allow the use of the suit storage slot.

## Media
![image](https://github.com/user-attachments/assets/a1767109-a321-4dee-b56a-8776e5d674d5)

