### PR TITLE
Added Round Removal Target

### DIFF
--- a/Resources/Locale/en-US/_Umbra/consents/consents.ftl
+++ b/Resources/Locale/en-US/_Umbra/consents/consents.ftl
@@ -1,11 +1,11 @@
 consent-syndicate-agent = Syndicate Agent
-consent-syndicate-agent-desc = Allow Game Masters to 'employ' you by The Syndicate for nefarious purposes.
+consent-syndicate-agent-desc = Allow Game Masters to 'employ' you by The Syndicate (or Syndicate subsidiary) for nefarious purposes.
 
 consent-get-kill-target = Syndicate Agent (with kill targets)
-consent-get-kill-target-desc = Allows you to, in addition, be given kill targets as a syndicate agent.
+consent-get-kill-target-desc = Allows you to, in addition, be given kill targets as a Syndicate (or Syndicate subsidiary) agent.
 
 consent-syndicate-thief = Syndicate Thief
-consent-syndicate-thief-desc = Allows Game Masters to assign you as a minor 'employee' of The Syndicate, whose sole goal is to steal things, nothing else.
+consent-syndicate-thief-desc = Allows Game Masters to assign you as a minor 'employee' of The Syndicate (or Syndicate subsidiary), whose sole goal is to steal things, nothing else.
 
 consent-thief-personal-gain = Thief (Personal Gain)
 consent-thief-personal-gain-desc = Allows Game Masters to assign you as a thief for your own gains! (Also includes other companies.)

--- a/Resources/Locale/en-US/_Umbra/consents/consents.ftl
+++ b/Resources/Locale/en-US/_Umbra/consents/consents.ftl
@@ -10,5 +10,8 @@ consent-syndicate-thief-desc = Allows Game Masters to assign you as a minor 'emp
 consent-thief-personal-gain = Thief (Personal Gain)
 consent-thief-personal-gain-desc = Allows Game Masters to assign you as a thief for your own gains! (Also includes other companies.)
 
-consent-be-kill-target = Allow kill targets
+consent-be-kill-target = Allow Kill Target
 consent-be-kill-target-desc = Allows Game Masters to assign you as a kill target of an antagonist.
+
+consent-be-round-removal-target = Allow Round Removal Target
+consent-be-round-removal-target-desc = Allows Game Masters to assign you to be round removed as a target of an antagonist.

--- a/Resources/Prototypes/_Umbra/Roles/Consents/consents.yml
+++ b/Resources/Prototypes/_Umbra/Roles/Consents/consents.yml
@@ -37,3 +37,11 @@
   antagonist: true
   setPreference: true
   visiblePreference: true
+
+- type: antag
+  id: ConsentBeRoundRemovalTarget
+  name: consent-be-round-removal-target
+  objective: consent-be-round-removal-target-desc
+  antagonist: true
+  setPreference: true
+  visiblePreference: true


### PR DESCRIPTION
## About the PR
Added a new Round Removal Target Antag option for players.

## Why / Balance
Gives the choice for players to consent to characters being round removed otherwise being gibbed, throw out into space, stopping revival etc.

## Media
![Screenshot_20241220_172731](https://github.com/user-attachments/assets/c451b001-6111-430c-b460-9ab62f73b752)


