### PR TITLE
Added Bnark and Bork to Vulp Emote Sound Triggers

### DIFF
--- a/Resources/Prototypes/_CD/Voice/speech_emotes.yml
+++ b/Resources/Prototypes/_CD/Voice/speech_emotes.yml
@@ -21,6 +21,26 @@
     - barked.
     - barked!
     - barking.
+    - bnark
+    - bnark.
+    - bnark!
+    - bnarks
+    - bnarks.
+    - bnarks!
+    - bnarked
+    - bnarked.
+    - bnarked!
+    - bnarking.
+    - bork
+    - bork.
+    - bork!
+    - borks
+    - borks.
+    - borks!
+    - borked
+    - borked.
+    - borked!
+    - borking.
 
 - type: emote
   id: Snarl

--- a/Resources/Prototypes/_CD/Voice/speech_emotes.yml
+++ b/Resources/Prototypes/_CD/Voice/speech_emotes.yml
@@ -21,7 +21,7 @@
     - barked.
     - barked!
     - barking.
-    - bnark
+    - bnark # Umbra: Bnark and Bork Emote Triggers START
     - bnark.
     - bnark!
     - bnarks
@@ -40,7 +40,7 @@
     - borked
     - borked.
     - borked!
-    - borking.
+    - borking. # Umbra: Bnark and Bork Emote Triggers END
 
 - type: emote
   id: Snarl


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Added new versions with full punctuation iterations to the barking emote sound:

- bnark
- bork

## Why / Balance
Bnark has become an Umbra inside joke and I thought it was time to finally make it work in the game. I added Bork as it also somewhat fit and someone did request it. I also just like bork as a word for comedy reasons.

## Media

![Screenshot_20241225_122320](https://github.com/user-attachments/assets/8b7f823d-ae7b-48fe-b4d3-4a47faf2fe85)
_Kai Vulp is not real_
