### PR TITLE
2nd Round of the Blood Update

### DIFF
--- a/Content.Client/_RMC/Medical/IV/IVDripSystem.cs
+++ b/Content.Client/_RMC/Medical/IV/IVDripSystem.cs
@@ -1,8 +1,8 @@
-﻿using Content.Shared._RMC14.Medical.IV;
+﻿using Content.Shared._RMC.Medical.IV;
 using Content.Shared.Rounding;
 using Robust.Client.GameObjects;
 
-namespace Content.Client._RMC14.Medical.IV;
+namespace Content.Client._RMC.Medical.IV;
 
 public sealed class IVDripSystem : SharedIVDripSystem
 {

--- a/Content.Server/_RMC/Medical/IV/IVDripSystem.cs
+++ b/Content.Server/_RMC/Medical/IV/IVDripSystem.cs
@@ -1,7 +1,7 @@
 ﻿using System.Diagnostics.CodeAnalysis;
 using Content.Server.Body.Components;
 using Content.Server.Chat.Systems;
-using Content.Shared._RMC14.Medical.IV;
+using Content.Shared._RMC.Medical.IV;
 using Content.Shared.Chat.Prototypes;
 using Content.Shared.Chemistry.Components;
 using Content.Shared.Chemistry.EntitySystems;
@@ -10,7 +10,7 @@ using Content.Shared.Damage;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Timing;
 
-namespace Content.Server._RMC14.Medical.IV;
+namespace Content.Server._RMC.Medical.IV;
 
 public sealed class IVDripSystem : SharedIVDripSystem
 {

--- a/Content.Server/_RMC/Medical/IV/IVDripSystem.cs
+++ b/Content.Server/_RMC/Medical/IV/IVDripSystem.cs
@@ -80,8 +80,7 @@ public sealed class IVDripSystem : SharedIVDripSystem
                 if (attachedStream is { } bloodSolutionEnt &&
                     bloodSolutionEnt.Comp.Solution.Volume < bloodSolutionEnt.Comp.Solution.MaxVolume)
                 {
-                    // Don't transfer non-blood reagants
-                    Solution excludedSolution = packSol.SplitSolutionWithout(packSol.MaxVolume, packComponent.TransferableReagents);
+                    Solution excludedSolution = packSol.SplitSolutionWithout(packSol.MaxVolume);
                     _solutionContainer.TryTransferSolution(bloodSolutionEnt, packSol, ivComp.TransferAmount);
                     _solutionContainer.TryAddSolution(packSolEnt.Value, excludedSolution);
                     Dirty(packSolEnt.Value);

--- a/Content.Shared/_RMC/Medical/IV/AttachBloodPackDoAfterEvent.cs
+++ b/Content.Shared/_RMC/Medical/IV/AttachBloodPackDoAfterEvent.cs
@@ -1,7 +1,7 @@
 ﻿using Content.Shared.DoAfter;
 using Robust.Shared.Serialization;
 
-namespace Content.Shared._RMC14.Medical.IV;
+namespace Content.Shared._RMC.Medical.IV;
 
 [Serializable, NetSerializable]
 public sealed partial class AttachBloodPackDoAfterEvent : SimpleDoAfterEvent;

--- a/Content.Shared/_RMC/Medical/IV/BloodPackComponent.cs
+++ b/Content.Shared/_RMC/Medical/IV/BloodPackComponent.cs
@@ -53,9 +53,6 @@ public sealed partial class BloodPackComponent : Component
     [DataField, AutoNetworkedField]
     public ProtoId<EmotePrototype> RipEmote = "Scream";
 
-    // TODO RMC-14 blood types
-    [DataField, AutoNetworkedField]
-    public string[] TransferableReagents = ["Blood"];
 }
 
 [Serializable, NetSerializable]

--- a/Content.Shared/_RMC/Medical/IV/BloodPackComponent.cs
+++ b/Content.Shared/_RMC/Medical/IV/BloodPackComponent.cs
@@ -53,6 +53,10 @@ public sealed partial class BloodPackComponent : Component
     [DataField, AutoNetworkedField]
     public ProtoId<EmotePrototype> RipEmote = "Scream";
 
+    // What reagents bloodpacks and IV stands can draw from the bloodstream.
+    // This should include all species blood.
+    [DataField, AutoNetworkedField]
+    public string[] BloodstreamReagents = ["Blood", "Sap", "AmmoniaBlood", "CopperBlood", "InsectBlood", "Slime", "SynthBlood"];
 }
 
 [Serializable, NetSerializable]

--- a/Content.Shared/_RMC/Medical/IV/BloodPackComponent.cs
+++ b/Content.Shared/_RMC/Medical/IV/BloodPackComponent.cs
@@ -1,4 +1,3 @@
-//using Content.Shared._RMC14.Marines.Skills;
 using Content.Shared.Chat.Prototypes;
 using Content.Shared.Damage;
 using Content.Shared.FixedPoint;
@@ -7,7 +6,7 @@ using Robust.Shared.Prototypes;
 using Robust.Shared.Serialization;
 using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom;
 
-namespace Content.Shared._RMC14.Medical.IV;
+namespace Content.Shared._RMC.Medical.IV;
 
 [RegisterComponent, NetworkedComponent, AutoGenerateComponentState(true), AutoGenerateComponentPause]
 public sealed partial class BloodPackComponent : Component
@@ -53,9 +52,6 @@ public sealed partial class BloodPackComponent : Component
 
     [DataField, AutoNetworkedField]
     public ProtoId<EmotePrototype> RipEmote = "Scream";
-
-    //[DataField, AutoNetworkedField]
-    //public Dictionary<EntProtoId<SkillDefinitionComponent>, int> SkillRequired = new() { ["RMCSkillSurgery"] = 1 };
 
     // TODO RMC-14 blood types
     [DataField, AutoNetworkedField]

--- a/Content.Shared/_RMC/Medical/IV/IVDripComponent.cs
+++ b/Content.Shared/_RMC/Medical/IV/IVDripComponent.cs
@@ -1,5 +1,4 @@
-﻿//using Content.Shared._RMC14.Marines.Skills;
-using Content.Shared.Chat.Prototypes;
+﻿using Content.Shared.Chat.Prototypes;
 using Content.Shared.Damage;
 using Content.Shared.FixedPoint;
 using Robust.Shared.GameStates;
@@ -7,7 +6,7 @@ using Robust.Shared.Prototypes;
 using Robust.Shared.Serialization;
 using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom;
 
-namespace Content.Shared._RMC14.Medical.IV;
+namespace Content.Shared._RMC.Medical.IV;
 
 [RegisterComponent, NetworkedComponent, AutoGenerateComponentState(true), AutoGenerateComponentPause]
 public sealed partial class IVDripComponent : Component
@@ -59,10 +58,6 @@ public sealed partial class IVDripComponent : Component
 
     [DataField, AutoNetworkedField]
     public ProtoId<EmotePrototype> RipEmote = "Scream";
-
-    //[DataField, AutoNetworkedField]
-
-    // public Dictionary<EntProtoId<SkillDefinitionComponent>, int> SkillRequired = new() { ["RMCSkillSurgery"] = 1 };
 }
 
 [Serializable, NetSerializable]

--- a/Content.Shared/_RMC/Medical/IV/SharedIVDripSystem.cs
+++ b/Content.Shared/_RMC/Medical/IV/SharedIVDripSystem.cs
@@ -10,13 +10,14 @@ using Content.Shared.Hands;
 using Content.Shared.Interaction;
 using Content.Shared.Popups;
 using Content.Shared.Verbs;
+using Content.Shared.Mind.Components;
 using Robust.Shared.Containers;
 using Robust.Shared.Network;
 using Robust.Shared.Player;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Timing;
 
-namespace Content.Shared._RMC14.Medical.IV;
+namespace Content.Shared._RMC.Medical.IV;
 
 public abstract class SharedIVDripSystem : EntitySystem
 {
@@ -24,7 +25,6 @@ public abstract class SharedIVDripSystem : EntitySystem
     [Dependency] private readonly DamageableSystem _damageable = default!;
     [Dependency] private readonly SharedDoAfterSystem _doAfter = default!;
     [Dependency] private readonly INetManager _net = default!;
-    //[Dependency] private readonly SkillsSystem _skills = default!;
     [Dependency] private readonly SharedPopupSystem _popup = default!;
     [Dependency] private readonly IPrototypeManager _prototype = default!;
     [Dependency] private readonly SharedSolutionContainerSystem _solutionContainer = default!;
@@ -48,9 +48,6 @@ public abstract class SharedIVDripSystem : EntitySystem
         SubscribeLocalEvent<IVDripComponent, InteractHandEvent>(OnIVInteractHand);
         SubscribeLocalEvent<IVDripComponent, GetVerbsEvent<InteractionVerb>>(OnIVVerbs);
         SubscribeLocalEvent<IVDripComponent, ExaminedEvent>(OnIVExamine);
-
-        // TODO RMC14 check for BloodstreamComponent instead of MarineComponent
-        //SubscribeLocalEvent<MarineComponent, CanDropTargetEvent>(OnMarineCanDropTarget);
 
         SubscribeLocalEvent<BloodPackComponent, MapInitEvent>(OnBloodPackMapInit);
         SubscribeLocalEvent<BloodPackComponent, AfterAutoHandleStateEvent>(OnBloodPackAfterState);
@@ -84,22 +81,9 @@ public abstract class SharedIVDripSystem : EntitySystem
 
     private void OnIVDripCanDropDragged(Entity<IVDripComponent> iv, ref CanDropDraggedEvent args)
     {
-        // TODO RMC14 check for BloodstreamComponent instead of MarineComponent
-        //if (!HasComp<MarineComponent>(args.Target) || !InRange(iv, args.Target, iv.Comp.Range))
-        //    return;
         args.Handled = true;
         args.CanDrop = true;
     }
-
-    // TODO RMC14 check for BloodstreamComponent instead of MarineComponent
-    /*     private void OnMarineCanDropTarget(Entity<MarineComponent> marine, ref CanDropTargetEvent args)
-    {
-        var iv = args.Dragged;
-        if (!TryComp(iv, out IVDripComponent? ivComp) || !InRange(iv, marine, ivComp.Range))
-            return;
-        args.Handled = true;
-        args.CanDrop = true;
-    } */
 
     private void OnIVDripDragDropDragged(Entity<IVDripComponent> iv, ref DragDropDraggedEvent args)
     {
@@ -179,9 +163,9 @@ public abstract class SharedIVDripSystem : EntitySystem
         if (args.Target is not { } target)
             return;
 
-        // TODO RMC14 check for BloodstreamComponent instead of MarineComponent
-        /*         if (!InRange(pack, target, pack.Comp.Range) || !HasComp<MarineComponent>(target))
-            return; */
+        // This should check for BloodstreamComponent but that isn't accessible to shared.
+        if (!InRange(pack, target, pack.Comp.Range) || !HasComp<MindContainerComponent>(target))
+            return;
 
         args.Handled = true;
 
@@ -191,12 +175,6 @@ public abstract class SharedIVDripSystem : EntitySystem
             DetachPack((pack, pack), user, false, true);
             return;
         }
-
-        /*         if (!_skills.HasAllSkills(user, pack.Comp.SkillRequired))
-        {
-            _popup.PopupClient(Loc.GetString("cm-iv-attach-no-skill"), user, user);
-            return;
-        } */
 
         if (user == target)
         {
@@ -284,12 +262,6 @@ public abstract class SharedIVDripSystem : EntitySystem
         if (!InRange(iv, to, iv.Comp.Range))
             return;
 
-        /*         if (!_skills.HasAllSkills(user, iv.Comp.SkillRequired))
-        {
-            _popup.PopupClient(Loc.GetString("cm-iv-attach-no-skill"), user, user);
-            return;
-        } */
-
         iv.Comp.AttachedTo = to;
         Dirty(iv);
 
@@ -300,12 +272,6 @@ public abstract class SharedIVDripSystem : EntitySystem
     {
         if (iv.Comp.AttachedTo is not { } target)
             return;
-
-        /*         if (user != null && !_skills.HasAllSkills(user.Value, iv.Comp.SkillRequired))
-        {
-            _popup.PopupClient(Loc.GetString("cm-iv-detach-no-skill"), user.Value, user.Value);
-            return;
-        } */
 
         iv.Comp.AttachedTo = default;
         Dirty(iv);
@@ -321,12 +287,6 @@ public abstract class SharedIVDripSystem : EntitySystem
         if (!InRange(pack, to, pack.Comp.Range))
             return;
 
-        /*         if (!_skills.HasAllSkills(user, pack.Comp.SkillRequired))
-        {
-            _popup.PopupClient(Loc.GetString("cm-iv-attach-no-skill"), user, user);
-            return;
-        } */
-
         pack.Comp.AttachedTo = to;
         Dirty(pack);
 
@@ -337,12 +297,6 @@ public abstract class SharedIVDripSystem : EntitySystem
     {
         if (pack.Comp.AttachedTo is not { } target)
             return;
-
-        /*         if (user != null && !_skills.HasAllSkills(user.Value, pack.Comp.SkillRequired))
-        {
-            _popup.PopupClient(Loc.GetString("cm-iv-detach-no-skill"), user.Value, user.Value);
-            return;
-        } */
 
         pack.Comp.AttachedTo = default;
         Dirty(pack);

--- a/Resources/Locale/en-US/_RMC/medical/iv.ftl
+++ b/Resources/Locale/en-US/_RMC/medical/iv.ftl
@@ -24,3 +24,12 @@ cm-blood-pack-cannot-self = You cannot connect this to yourself.
 cm-blood-pack-poke-self = You poke {$target} with {$pack}.
 cm-blood-pack-poke-others = {$user} pokes {$target} with {$pack}.
 cm-blood-pack-contains = It contains: [color=#BB0000FF]{$units} units[/color] of liquid.
+
+cm-blood-pack-empty = Empty
+cm-blood-pack-reagent-redblood = Blood
+cm-blood-pack-reagent-sapblood = Sap
+cm-blood-pack-reagent-ammoniablood = Ammonia
+cm-blood-pack-reagent-copperblood = Hemocyanin
+cm-blood-pack-reagent-insectblood = Insect
+cm-blood-pack-reagent-synthblood = Coolant
+cm-blood-pack-reagent-slimeblood = Slime

--- a/Resources/Locale/en-US/_Umbra/guidebook/medical.ftl
+++ b/Resources/Locale/en-US/_Umbra/guidebook/medical.ftl
@@ -1,0 +1,1 @@
+guidebook-name-rmcmedical = Placeholder

--- a/Resources/Locale/en-US/_Umbra/guidebook/medical.ftl
+++ b/Resources/Locale/en-US/_Umbra/guidebook/medical.ftl
@@ -1,1 +1,1 @@
-guidebook-name-rmcmedical = Placeholder
+guidebook-name-rmcmedical = IV Stands and Blood Packs

--- a/Resources/Prototypes/Catalog/Fills/Crates/medical.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/medical.yml
@@ -10,7 +10,8 @@
         amount: 2
       - id: Gauze
         amount: 2
-      - id: Bloodpack
+      #- id: Bloodpack # Umbra: Replaced with RMC Blood.
+      - id: CMBloodPackFull
         amount: 2
       - id: BoxLatexGloves
       - id: BoxSterileMask

--- a/Resources/Prototypes/Catalog/Fills/Items/belt.yml
+++ b/Resources/Prototypes/Catalog/Fills/Items/belt.yml
@@ -96,7 +96,8 @@
         amount: 2
       - id: Ointment
         amount: 1
-      - id: Bloodpack
+      #- id: Bloodpack # Umbra: Replaced with RMC Blood.
+      - id: CMBloodPackFull
         amount: 1
       - id: Gauze
       - id: EmergencyMedipen #You never know what people are going to latejoin into
@@ -110,7 +111,8 @@
     contents:
       - id: Brutepack
       - id: Ointment
-      - id: Bloodpack
+      #- id: Bloodpack # Umbra: Replaced by RMC blood.
+      - id: CMBloodPackFull
       - id: Gauze
       - id: EmergencyMedipen #You never know what people are going to latejoin into
         amount: 3

--- a/Resources/Prototypes/Catalog/Fills/Items/firstaidkits.yml
+++ b/Resources/Prototypes/Catalog/Fills/Items/firstaidkits.yml
@@ -86,6 +86,7 @@
       #- id: Bloodpack #Umbra: Replaced by RMC blood.
       #  amount: 2
       - id: CMBloodPackFull
+        amount: 2
 
 - type: entity
   id: MedkitCombatFilled

--- a/Resources/Prototypes/Catalog/Fills/Items/firstaidkits.yml
+++ b/Resources/Prototypes/Catalog/Fills/Items/firstaidkits.yml
@@ -83,8 +83,9 @@
     contents:
       - id: MedicatedSuture
       - id: RegenerativeMesh
-      - id: Bloodpack
-        amount: 2
+      #- id: Bloodpack #Umbra: Replaced by RMC blood.
+      #  amount: 2
+      - id: CMBloodPackFull
 
 - type: entity
   id: MedkitCombatFilled

--- a/Resources/Prototypes/Catalog/Fills/Lockers/medical.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/medical.yml
@@ -12,7 +12,8 @@
         amount: 2
       - id: Ointment
         amount: 2
-      - id: Bloodpack
+      #- id: Bloodpack #Umbra: Replaced by RMC blood.
+      - id: CMBloodPackFull
         amount: 2
       - id: Gauze
 
@@ -31,8 +32,9 @@
         amount: 2
       - id: Ointment
         amount: 2
-      - id: Bloodpack
-        amount: 2
+      #- id: Bloodpack # Umbra: Replaced by RMC blood.
+      #  amount: 2
+      - id: CMBloodPackFull
       - id: Gauze
 
 

--- a/Resources/Prototypes/Catalog/Fills/Lockers/medical.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/medical.yml
@@ -13,6 +13,7 @@
       - id: Ointment
         amount: 2
       #- id: Bloodpack #Umbra: Replaced by RMC blood.
+      #  amount: 2
       - id: CMBloodPackFull
         amount: 2
       - id: Gauze
@@ -35,6 +36,7 @@
       #- id: Bloodpack # Umbra: Replaced by RMC blood.
       #  amount: 2
       - id: CMBloodPackFull
+        amount: 2
       - id: Gauze
 
 

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/medical.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/medical.yml
@@ -6,6 +6,12 @@
     Ointment: 5
     #Bloodpack: 5 #Umbra: Replaced by RMC Blood Patch.
     CMBloodPackFull: 5 #Umbra
+    CMBloodPackFullSap: 3 #Umbra
+    CMBloodPackFullAnaerobic: 3 #Umbra
+    CMBloodPackFullHemocyanin: 3 #Umbra
+    CMBloodPackFullInsect: 3 #Umbra
+    CMBloodPackFullSlime: 3 #Umbra
+    CMBloodPackFullSynthetic: 3 #Umbra
     CMBloodPack: 5 #Umbra: Few free empty bags for medical to fill.
     IVstandflatpack: 3 #Umbra
     EpinephrineChemistryBottle: 3

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/wallmed.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/wallmed.yml
@@ -5,6 +5,12 @@
     Ointment: 3
     #Bloodpack: 5 #Umbra: Replaced by RMC Blood Patch.
     CMBloodPackFull: 5 #Umbra
+    CMBloodPackFullSap: 3 #Umbra
+    CMBloodPackFullAnaerobic: 3 #Umbra
+    CMBloodPackFullHemocyanin: 3 #Umbra
+    CMBloodPackFullInsect: 3 #Umbra
+    CMBloodPackFullSlime: 3 #Umbra
+    CMBloodPackFullSynthetic: 3 #Umbra
     CMBloodPack: 5 #Umbra: Few free empty bags for medical to fill.
     EpinephrineChemistryBottle: 3
     Syringe: 3

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/wallmed.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/wallmed.yml
@@ -12,5 +12,6 @@
     CMBloodPackFullSlime: 3 #Umbra
     CMBloodPackFullSynthetic: 3 #Umbra
     CMBloodPack: 5 #Umbra: Few free empty bags for medical to fill.
+    IVstandflatpack: 1 #Umbra
     EpinephrineChemistryBottle: 3
     Syringe: 3

--- a/Resources/Prototypes/Entities/Objects/Specific/Robotics/borg_modules.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Robotics/borg_modules.yml
@@ -385,7 +385,7 @@
     - Ointment10Lingering
     - Gauze10Lingering
     #- Bloodpack10Lingering #Umbra: Replaced by RMC Blood.
-    - CMBloodpack10Lingering
+    - CMBloodpackLingering
     - Syringe
   - type: BorgModuleIcon
     icon: { sprite: Interface/Actions/actions_borg.rsi, state: treatment-module }

--- a/Resources/Prototypes/Entities/Objects/Specific/Robotics/borg_modules.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Robotics/borg_modules.yml
@@ -384,7 +384,8 @@
     - Brutepack10Lingering
     - Ointment10Lingering
     - Gauze10Lingering
-    - Bloodpack10Lingering
+    #- Bloodpack10Lingering #Umbra: Replaced by RMC Blood.
+    - CMBloodpack10Lingering
     - Syringe
   - type: BorgModuleIcon
     icon: { sprite: Interface/Actions/actions_borg.rsi, state: treatment-module }

--- a/Resources/Prototypes/Guidebook/medical.yml
+++ b/Resources/Prototypes/Guidebook/medical.yml
@@ -7,6 +7,7 @@
   - Chemist
   - Cloning
   - Cryogenics
+  - Rmcmedical #Umbra RMC Blood
 
 - type: guideEntry
   id: Medical Doctor

--- a/Resources/Prototypes/Roles/Jobs/Fun/visitors_startinggear.yml
+++ b/Resources/Prototypes/Roles/Jobs/Fun/visitors_startinggear.yml
@@ -789,7 +789,8 @@
     pocket1: Ointment
     pocket2: Brutepack
   inhand:
-  - Bloodpack
+  # - Bloodpack #Umbra: Replaced by RMC blood.
+  - CMBloodPackFull
   - Gauze
 
 - type: startingGear
@@ -806,7 +807,8 @@
     pocket1: Ointment
     pocket2: Brutepack
   inhand:
-  - Bloodpack
+  #- Bloodpack #Umbra: Replaced by RMC Blood.
+  - CMBloodPackFull
   - Gauze
 
 - type: startingGear

--- a/Resources/Prototypes/_RMC/Entities/Structures/Marchines/Medical/iv.yml
+++ b/Resources/Prototypes/_RMC/Entities/Structures/Marchines/Medical/iv.yml
@@ -51,6 +51,9 @@
   - type: ContainerContainer
     containers:
       pack: !type:ContainerSlot {}
+  - type: GuideHelp
+    guides:
+    - Rmcmedical
 
 - type: entity
   parent: BaseItem
@@ -238,7 +241,7 @@
   - type: Label
     currentLabel: cm-blood-pack-reagent-slimeblood
 
-#TODO
+# TODO
 # Crafting recipies for blood? (In Discussion)
 # Write the guidebook entry for how IV stands and Guidebooks work
 # Make sure IVs can inject any reagents from bloodbags so I'm not a liar (Also so our different bloodtypes matter.)- Alex

--- a/Resources/Prototypes/_RMC/Entities/Structures/Marchines/Medical/iv.yml
+++ b/Resources/Prototypes/_RMC/Entities/Structures/Marchines/Medical/iv.yml
@@ -222,4 +222,5 @@
 #Test borg lingering bloodpacks - Broken
 #Test the random bag fills.
   #If needed, make them only be an ammount of 1.
+# Crafting recipies for blood? (In Discussion)
 # Write the guidebook entry for how IV stands and Guidebooks work

--- a/Resources/Prototypes/_RMC/Entities/Structures/Marchines/Medical/iv.yml
+++ b/Resources/Prototypes/_RMC/Entities/Structures/Marchines/Medical/iv.yml
@@ -244,7 +244,6 @@
 # TODO
 # Crafting recipies for blood? (In Discussion)
 
-# Write a guidebook entry for both IV stands and Blood Packs
 # IVs and Bloodbags should inject into the chem stream, not blood stream.
 # Remove the IV and Blood Pack reagent whitelist.
   # In its place, IV and Bloodbag DRAW function should only pull a whitelist so they only draw species blood from people.

--- a/Resources/Prototypes/_RMC/Entities/Structures/Marchines/Medical/iv.yml
+++ b/Resources/Prototypes/_RMC/Entities/Structures/Marchines/Medical/iv.yml
@@ -243,6 +243,8 @@
 
 # TODO
 # Crafting recipies for blood? (In Discussion)
-# Write the guidebook entry for how IV stands and Guidebooks work
-# Make sure IVs can inject any reagents from bloodbags so I'm not a liar (Also so our different bloodtypes matter.)- Alex
-# Find the component that I missed in the port over preventing injecting into random entities.
+
+# Write a guidebook entry for both IV stands and Blood Packs
+# IVs and Bloodbags should inject into the chem stream, not blood stream.
+# Find the component to prevent bloodpacks/ivs from injecting into all entities.
+# Remove the IV and Blood Pack reagent whitelist.

--- a/Resources/Prototypes/_RMC/Entities/Structures/Marchines/Medical/iv.yml
+++ b/Resources/Prototypes/_RMC/Entities/Structures/Marchines/Medical/iv.yml
@@ -55,7 +55,7 @@
 - type: entity
   parent: BaseItem
   id: CMBloodPack
-  name: empty blood pack
+  name: blood pack
   description: A blood pack. Contains fluids, typically used for transfusions.
   suffix: CM, empty
   components:
@@ -99,6 +99,8 @@
   - type: GuideHelp
     guides:
     - Rmcmedical
+  - type: Label
+    currentLabel: cm-blood-pack-empty
 
 - type: entity
   parent: CMBloodPack
@@ -113,6 +115,8 @@
         reagents:
         - ReagentId: Blood
           Quantity: 120
+  - type: Label
+    currentLabel: cm-blood-pack-reagent-redblood
 
 # Umbra Blood Pack Types
 # Lingering
@@ -141,6 +145,8 @@
         reagents:
         - ReagentId: Sap
           Quantity: 120
+  - type: Label
+    currentLabel: cm-blood-pack-reagent-sapblood
 
 # Anaerobic
 - type: entity
@@ -157,6 +163,8 @@
         reagents:
         - ReagentId: AmmoniaBlood
           Quantity: 120
+  - type: Label
+    currentLabel: cm-blood-pack-reagent-ammoniablood
 
 # Blue Blood
 - type: entity
@@ -173,6 +181,8 @@
         reagents:
         - ReagentId: CopperBlood
           Quantity: 120
+  - type: Label
+    currentLabel: cm-blood-pack-reagent-copperblood
 
 # Insect Blood
 - type: entity
@@ -189,6 +199,8 @@
         reagents:
         - ReagentId: InsectBlood
           Quantity: 120
+  - type: Label
+    currentLabel: cm-blood-pack-reagent-insectblood
 
 # Synthetic Blood
 - type: entity
@@ -205,6 +217,8 @@
         reagents:
         - ReagentId: SynthBlood
           Quantity: 120
+  - type: Label
+    currentLabel: cm-blood-pack-reagent-synthblood
 
 # Slime Blood
 - type: entity
@@ -221,6 +235,8 @@
         reagents:
         - ReagentId: Slime
           Quantity: 120
+  - type: Label
+    currentLabel: cm-blood-pack-reagent-slimeblood
 
 #TODO
 # Crafting recipies for blood? (In Discussion)

--- a/Resources/Prototypes/_RMC/Entities/Structures/Marchines/Medical/iv.yml
+++ b/Resources/Prototypes/_RMC/Entities/Structures/Marchines/Medical/iv.yml
@@ -1,5 +1,5 @@
 - type: entity
-  parent: BaseStructure #Fix
+  parent: BaseStructure
   id: CMIV
   name: iv
   description: Allows you to inject blood into a patient or extract blood from them to do a blood transfusion.
@@ -54,7 +54,7 @@
 
 - type: entity
   parent: BaseItem
-  id: CMBloodPack # TODO RMC14 blood types
+  id: CMBloodPack
   name: empty blood pack
   description: A blood pack. Contains fluids, typically used for transfusions.
   suffix: CM, empty
@@ -83,10 +83,10 @@
     solution: pack
   - type: InjectableSolution
     solution: pack
-  - type: Damageable # TODO?
+  - type: Damageable
     damageContainer: Inorganic
     damageModifierSet: Glass
-  - type: DamageOnHighSpeedImpact # TODO
+  - type: DamageOnHighSpeedImpact
     minimumSpeed: 2
     damage:
       types:
@@ -96,7 +96,7 @@
 
 - type: entity
   parent: CMBloodPack
-  id: CMBloodPackFull # TODO RMC14 blood types
+  id: CMBloodPackFull
   name: blood pack
   suffix: CM, Full
   components:
@@ -107,3 +107,100 @@
         reagents:
         - ReagentId: Blood
           Quantity: 300
+
+# Umbra Blood Pack Types
+# Lingering
+- type: entity
+  parent: CMBloodPack
+  id: CMBloodpack10Lingering
+  suffix: 1, Lingering
+  components:
+  - type: Stack
+    lingering: true
+
+#Sap
+- type: entity
+  parent: CMBloodPack
+  id: CMBloodPackFullSap
+  name: blood pack
+  description: A blood pack. Contains fluids, typically used for transfusions. This one contains sap, used for Diona.
+  suffix: CM, Full, Sap
+  components:
+  - type: SolutionContainerManager
+    solutions:
+      pack:
+        maxVol: 300
+        reagents:
+        - ReagentId: Sap
+          Quantity: 300
+
+#Anaerobic
+- type: entity
+  parent: CMBloodPack
+  id: CMBloodPackFullAnaerobic
+  name: blood pack
+  description: A blood pack. Contains fluids, typically used for transfusions. This one was filled with Ammonia, used for Vox and Avali.
+  suffix: CM, Full, Anaerobic/Ammonia
+  components:
+  - type: SolutionContainerManager
+    solutions:
+      pack:
+        maxVol: 300
+        reagents:
+        - ReagentId: AmmoniaBlood
+          Quantity: 300
+
+#Blue Blood
+- type: entity
+  parent: CMBloodPack
+  id: CMBloodPackFullHemocyanin
+  name: blood pack
+  description: A blood pack. Contains fluids, typically used for transfusions. This one was filled with Hemocyanin, used for Arachnids.
+  suffix: CM, Full, Hemocyanin/Blue
+  components:
+  - type: SolutionContainerManager
+    solutions:
+      pack:
+        maxVol: 300
+        reagents:
+        - ReagentId: CopperBlood
+          Quantity: 300
+
+#Insect Blood
+- type: entity
+  parent: CMBloodPack
+  id: CMBloodPackFullInsect
+  name: blood pack
+  description: A blood pack. Contains fluids, typically used for transfusions. This one was filled with insect blood, used for moths.
+  suffix: CM, Full, Insect/Moth
+  components:
+  - type: SolutionContainerManager
+    solutions:
+      pack:
+        maxVol: 300
+        reagents:
+        - ReagentId: InsectBlood
+          Quantity: 300
+
+#Synthetic Blood
+- type: entity
+  parent: CMBloodPack
+  id: CMBloodPackFullSynthetic
+  name: blood pack
+  description: A blood pack. Contains fluids, typically used for transfusions. This one was filled with a type of coolant, used for synths.
+  suffix: CM, Full, Syntetic
+  components:
+  - type: SolutionContainerManager
+    solutions:
+      pack:
+        maxVol: 300
+        reagents:
+        - ReagentId: SynthBlood
+          Quantity: 300
+
+#TODO
+#Add 3 of each specialty blood to vendors.
+#Test borg lingering bloodpacks
+#Test the random bag fills.
+  #If needed, make them only be an ammount of 1.
+#Guidebook entry on how the bloodpacks and IV stands work.

--- a/Resources/Prototypes/_RMC/Entities/Structures/Marchines/Medical/iv.yml
+++ b/Resources/Prototypes/_RMC/Entities/Structures/Marchines/Medical/iv.yml
@@ -242,9 +242,9 @@
     currentLabel: cm-blood-pack-reagent-slimeblood
 
 # TODO
+# YAML
 # Crafting recipies for blood? (In Discussion)
+# Injecting the wrong species blood into someone should cause some type of damage (In Discussion).
 
-# IVs and Bloodbags should inject into the chem stream, not blood stream.
-# Remove the IV and Blood Pack reagent whitelist.
-  # In its place, IV and Bloodbag DRAW function should only pull a whitelist so they only draw species blood from people.
-  # Injecting the wrong species blood into someone should cause some type of damage (In Discussion).
+# CS
+# IVs and Bloodbags should inject into the chem stream, unless its blood which should then go into the bloodstream.

--- a/Resources/Prototypes/_RMC/Entities/Structures/Marchines/Medical/iv.yml
+++ b/Resources/Prototypes/_RMC/Entities/Structures/Marchines/Medical/iv.yml
@@ -75,7 +75,7 @@
   - type: SolutionContainerManager
     solutions:
       pack:
-        maxVol: 300
+        maxVol: 120
   - type: SolutionTransfer
     canChangeTransferAmount: true
   - type: Appearance
@@ -109,10 +109,10 @@
   - type: SolutionContainerManager
     solutions:
       pack:
-        maxVol: 300
+        maxVol: 120
         reagents:
         - ReagentId: Blood
-          Quantity: 300
+          Quantity: 120
 
 # Umbra Blood Pack Types
 # Lingering
@@ -122,6 +122,8 @@
   suffix: Lingering
   components:
   - type: Stack
+    stackType: Fulton
+    count: 1
     lingering: true
 
 # Sap
@@ -135,10 +137,10 @@
   - type: SolutionContainerManager
     solutions:
       pack:
-        maxVol: 300
+        maxVol: 120
         reagents:
         - ReagentId: Sap
-          Quantity: 300
+          Quantity: 120
 
 # Anaerobic
 - type: entity
@@ -151,10 +153,10 @@
   - type: SolutionContainerManager
     solutions:
       pack:
-        maxVol: 300
+        maxVol: 120
         reagents:
         - ReagentId: AmmoniaBlood
-          Quantity: 300
+          Quantity: 120
 
 # Blue Blood
 - type: entity
@@ -167,10 +169,10 @@
   - type: SolutionContainerManager
     solutions:
       pack:
-        maxVol: 300
+        maxVol: 120
         reagents:
         - ReagentId: CopperBlood
-          Quantity: 300
+          Quantity: 120
 
 # Insect Blood
 - type: entity
@@ -183,10 +185,10 @@
   - type: SolutionContainerManager
     solutions:
       pack:
-        maxVol: 300
+        maxVol: 120
         reagents:
         - ReagentId: InsectBlood
-          Quantity: 300
+          Quantity: 120
 
 # Synthetic Blood
 - type: entity
@@ -194,15 +196,15 @@
   id: CMBloodPackFullSynthetic
   name: blood pack
   description: A blood pack. Contains fluids, typically used for transfusions. This one was filled with a type of coolant, used for synths.
-  suffix: Full, Syntetic
+  suffix: Full, Synthetic
   components:
   - type: SolutionContainerManager
     solutions:
       pack:
-        maxVol: 300
+        maxVol: 120
         reagents:
         - ReagentId: SynthBlood
-          Quantity: 300
+          Quantity: 120
 
 # Slime Blood
 - type: entity
@@ -215,13 +217,13 @@
   - type: SolutionContainerManager
     solutions:
       pack:
-        maxVol: 300
+        maxVol: 120
         reagents:
         - ReagentId: Slime
-          Quantity: 300
+          Quantity: 120
 
 #TODO
-#Add 3 of each specialty blood to vendors.
-#Test borg lingering bloodpacks - Broken
 # Crafting recipies for blood? (In Discussion)
 # Write the guidebook entry for how IV stands and Guidebooks work
+# Make sure IVs can inject any reagents from bloodbags so I'm not a liar (Also so our different bloodtypes matter.)- Alex
+# Find the component that I missed in the port over preventing injecting into random entities.

--- a/Resources/Prototypes/_RMC/Entities/Structures/Marchines/Medical/iv.yml
+++ b/Resources/Prototypes/_RMC/Entities/Structures/Marchines/Medical/iv.yml
@@ -204,3 +204,4 @@
 #Test the random bag fills.
   #If needed, make them only be an ammount of 1.
 #Guidebook entry on how the bloodpacks and IV stands work.
+  # Add the "help" button to the IV stands and blood bags.

--- a/Resources/Prototypes/_RMC/Entities/Structures/Marchines/Medical/iv.yml
+++ b/Resources/Prototypes/_RMC/Entities/Structures/Marchines/Medical/iv.yml
@@ -93,6 +93,9 @@
         Blunt: 5
   - type: StaticPrice
     price: 30
+  - type: Tag
+    tags:
+    - Bloodpack
   - type: GuideHelp
     guides:
     - Rmcmedical
@@ -115,7 +118,7 @@
 # Lingering
 - type: entity
   parent: CMBloodPack
-  id: CMBloodpack10Lingering
+  id: CMBloodpackLingering
   suffix: Lingering
   components:
   - type: Stack
@@ -220,7 +223,5 @@
 #TODO
 #Add 3 of each specialty blood to vendors.
 #Test borg lingering bloodpacks - Broken
-#Test the random bag fills.
-  #If needed, make them only be an ammount of 1.
 # Crafting recipies for blood? (In Discussion)
 # Write the guidebook entry for how IV stands and Guidebooks work

--- a/Resources/Prototypes/_RMC/Entities/Structures/Marchines/Medical/iv.yml
+++ b/Resources/Prototypes/_RMC/Entities/Structures/Marchines/Medical/iv.yml
@@ -246,5 +246,6 @@
 
 # Write a guidebook entry for both IV stands and Blood Packs
 # IVs and Bloodbags should inject into the chem stream, not blood stream.
-# Find the component to prevent bloodpacks/ivs from injecting into all entities.
 # Remove the IV and Blood Pack reagent whitelist.
+  # In its place, IV and Bloodbag DRAW function should only pull a whitelist so they only draw species blood from people.
+  # Injecting the wrong species blood into someone should cause some type of damage (In Discussion).

--- a/Resources/Prototypes/_RMC/Entities/Structures/Marchines/Medical/iv.yml
+++ b/Resources/Prototypes/_RMC/Entities/Structures/Marchines/Medical/iv.yml
@@ -93,6 +93,9 @@
         Blunt: 5
   - type: StaticPrice
     price: 30
+  - type: GuideHelp
+    guides:
+    - Rmcmedical
 
 - type: entity
   parent: CMBloodPack
@@ -113,18 +116,18 @@
 - type: entity
   parent: CMBloodPack
   id: CMBloodpack10Lingering
-  suffix: 1, Lingering
+  suffix: Lingering
   components:
   - type: Stack
     lingering: true
 
-#Sap
+# Sap
 - type: entity
   parent: CMBloodPack
   id: CMBloodPackFullSap
   name: blood pack
   description: A blood pack. Contains fluids, typically used for transfusions. This one contains sap, used for Diona.
-  suffix: CM, Full, Sap
+  suffix: Full, Sap
   components:
   - type: SolutionContainerManager
     solutions:
@@ -134,13 +137,13 @@
         - ReagentId: Sap
           Quantity: 300
 
-#Anaerobic
+# Anaerobic
 - type: entity
   parent: CMBloodPack
   id: CMBloodPackFullAnaerobic
   name: blood pack
   description: A blood pack. Contains fluids, typically used for transfusions. This one was filled with Ammonia, used for Vox and Avali.
-  suffix: CM, Full, Anaerobic/Ammonia
+  suffix: Full, Anaerobic/Ammonia
   components:
   - type: SolutionContainerManager
     solutions:
@@ -150,13 +153,13 @@
         - ReagentId: AmmoniaBlood
           Quantity: 300
 
-#Blue Blood
+# Blue Blood
 - type: entity
   parent: CMBloodPack
   id: CMBloodPackFullHemocyanin
   name: blood pack
   description: A blood pack. Contains fluids, typically used for transfusions. This one was filled with Hemocyanin, used for Arachnids.
-  suffix: CM, Full, Hemocyanin/Blue
+  suffix: Full, Hemocyanin/Blue
   components:
   - type: SolutionContainerManager
     solutions:
@@ -166,13 +169,13 @@
         - ReagentId: CopperBlood
           Quantity: 300
 
-#Insect Blood
+# Insect Blood
 - type: entity
   parent: CMBloodPack
   id: CMBloodPackFullInsect
   name: blood pack
   description: A blood pack. Contains fluids, typically used for transfusions. This one was filled with insect blood, used for moths.
-  suffix: CM, Full, Insect/Moth
+  suffix: Full, Insect/Moth
   components:
   - type: SolutionContainerManager
     solutions:
@@ -182,13 +185,13 @@
         - ReagentId: InsectBlood
           Quantity: 300
 
-#Synthetic Blood
+# Synthetic Blood
 - type: entity
   parent: CMBloodPack
   id: CMBloodPackFullSynthetic
   name: blood pack
   description: A blood pack. Contains fluids, typically used for transfusions. This one was filled with a type of coolant, used for synths.
-  suffix: CM, Full, Syntetic
+  suffix: Full, Syntetic
   components:
   - type: SolutionContainerManager
     solutions:
@@ -198,10 +201,25 @@
         - ReagentId: SynthBlood
           Quantity: 300
 
+# Slime Blood
+- type: entity
+  parent: CMBloodPack
+  id: CMBloodPackFullSlime
+  name: blood pack
+  description: A blood pack. Contains fluids, typically used for transfusions. This one was filled with a type of slime, used for slime people.
+  suffix: Full, Slime
+  components:
+  - type: SolutionContainerManager
+    solutions:
+      pack:
+        maxVol: 300
+        reagents:
+        - ReagentId: Slime
+          Quantity: 300
+
 #TODO
 #Add 3 of each specialty blood to vendors.
-#Test borg lingering bloodpacks
+#Test borg lingering bloodpacks - Broken
 #Test the random bag fills.
   #If needed, make them only be an ammount of 1.
-#Guidebook entry on how the bloodpacks and IV stands work.
-  # Add the "help" button to the IV stands and blood bags.
+# Write the guidebook entry for how IV stands and Guidebooks work

--- a/Resources/Prototypes/_Umbra/Guidebook/medical.yml
+++ b/Resources/Prototypes/_Umbra/Guidebook/medical.yml
@@ -1,0 +1,4 @@
+- type: guideEntry
+  id: Rmcmedical
+  name: guidebook-name-rmcmedical
+  text: "/ServerInfo/Guidebook/_Umbra/Rmcmedical.xml"

--- a/Resources/ServerInfo/Guidebook/_Umbra/Rmcmedical.xml
+++ b/Resources/ServerInfo/Guidebook/_Umbra/Rmcmedical.xml
@@ -6,8 +6,6 @@
   </Box>
 
   Blood bags can store 120 Units of any reagent, but can only be manually filled through injectors (Ex: Syringes, Hypospray, IV Stands).
-  Blood bags will inject into the blood stream, not the chemical stream.
- - List of blood variants and what species they coorospond to
  - Blood bags can inject any chemical they store.
 
   ## IV Stands
@@ -23,24 +21,21 @@
     <GuideEntityEmbed Entity="CMIV" State="Unhooked" Caption="IV Stand"/>
   </Box>
 
-  - IV Stand Injecting
-  In order to make proper use of IV Stands, you must first
-  
-  - Toggle Inject Button
+  Once an IV Stand has been deplyoed, it will need a blood pack insterted into it before it can serve any use. IV Stands will take a blood bag wether it is filled or empty.
 
-  While an Iv is injected inside of a pateint, it is possible for the IV needle itself to rip out of a patient's arm. This occurs when an IV stand or Patient move to far away from one another.
-  
-  IV Stands are also capable of drawing from a patient. This will slowly drain the patient of their bloodstream's content and fill the IV Stand's bloodbag.
+  Most commonly, you will insert a filled pack. This will allow the IV stand to inject the contents of the blood pack into your patient's chemical stream, including mixtures.
 
-  IV Stands inject into a patient's blood stream, not chemical stream.
+  Alternatively, IV stands can store empty blood packs. By using the "Toggle Inject" verb, the IV stand will draw from the patient's blood stream. This will slowly drain the patient's bloodstream contents and fill the IV Stand's blood pack.
+
+  While an Iv is injected inside of a pateint, it is possible for the IV needle itself to rip out of a patient's arm. This occurs when an IV stand and/or Patient move to far away from one another.
 
   ## Summary
 
   - Blood bags are able to store 120 Units of any reagent.
-  - Both IV Stands and Blood Bags inject into the blood stream, not the chemical stream.
+  - Both IV Stands and Blood Bags inject into the chemical stream, but draw from the blood stream.
   - When used on a patient blood bags will slowly inject a patient with their contained reagents, including mixtures.
   - Empty blood bags can be filled using any injector (Ex: Syringes/Hyposprays) or IV Stands.
-  - IV Stands can draw or inject from a patient.
+  - IV Stands can draw or inject from a patient, these modes can be switched using the "Toggle Inject" verb.
   
   Below is a table for the different types of blood and what species they corrolate to:
   - [color=#7a8bf2]Ammonia Blood[/color]: Vox, Avali

--- a/Resources/ServerInfo/Guidebook/_Umbra/Rmcmedical.xml
+++ b/Resources/ServerInfo/Guidebook/_Umbra/Rmcmedical.xml
@@ -1,5 +1,6 @@
 <Document>
-  # Overview
+  TODO
+  Color Coding Certain Important Things
 
   ## Blood Bags
 
@@ -7,15 +8,31 @@
     <GuideEntityEmbed Entity="CMBloodPack" Caption="Standard Blood Bag"/>
   </Box>
 
+  What blood bags do
+  Blood bags store 300U
+  List of blood variants and what species they coorospond to
+  Blood bags can inject any chemical they store.
+
   ## IV Stands
 
   <Box>
     <GuideEntityEmbed Entity="CMIV" State="Unhooked" Caption="Standard IV Stand"/>
   </Box>
 
-  Adapted to live in cold envinronments, their bodies are capable of handling extremely cold temperatures. Their temperature range is
-  [color=#12ABE8] approximately -50C to -35C[/color]. Additionally, due to their traditionally smaller stature [color=#ffa500]
-  they are 5% less dense than the average species[/color] meaning they are slightly more susceptible to being shoved over
-  and its more difficult for them to pull objects.
+  IV Stand Flatpacks
+  IV Stand Injecting
+  In order to make proper use of IV Stands, you must first
+  
+  Toggle Inject Button
+
+  While an Iv is injected inside of a pateint, it is possible for the IV needle itself to rip out of a patient's arm. This occurs when an IV stand or Patient move to far away from one another.
+  
+  IV Stands are also capable of drawing from a patient. This will slowly drain the patient of their bloodstream's content and fill the IV Stand's bloodbag.
+
+  ## Summary
+
+  - Blood bags are able to store 300 Units of any reagent.
+  - When used on a patient blood bags will slowly inject a patient with their contained reagents, including mixtures.
+  - Empty blood bags can be filled using any injector (Ex: Syringes/Hyposprays) or IV Stands.
 
 </Document>

--- a/Resources/ServerInfo/Guidebook/_Umbra/Rmcmedical.xml
+++ b/Resources/ServerInfo/Guidebook/_Umbra/Rmcmedical.xml
@@ -1,30 +1,32 @@
 <Document>
-  TODO
-  Color Coding Certain Important Things
-
   ## Blood Bags
 
   <Box>
     <GuideEntityEmbed Entity="CMBloodPack" Caption="Standard Blood Bag"/>
   </Box>
 
-  What blood bags do
-  Blood bags store 120U
-  List of blood variants and what species they coorospond to
-  Blood bags can inject any chemical they store.
-  Blood bags inject into a patient's blood stream, not chemical stream.
+  Blood bags can store 120 Units of any reagent, but can only be manually filled through injectors (Ex: Syringes, Hypospray, IV Stands).
+  Blood bags will inject into the blood stream, not the chemical stream.
+ - List of blood variants and what species they coorospond to
+ - Blood bags can inject any chemical they store.
 
   ## IV Stands
 
   <Box>
-    <GuideEntityEmbed Entity="CMIV" State="Unhooked" Caption="Standard IV Stand"/>
+    <GuideEntityEmbed Entity="VendingMachineMedical" State="normal-unshaded" Caption="Nanomed"/>
+    <GuideEntityEmbed Entity="IVstandflatpack" Caption="IV Stand Flatpack"/>
   </Box>
 
-  IV Stand Flatpacks
-  IV Stand Injecting
+  IV Stand Flatpacks can be found in [color=#5b97bc]Nanomed[/color] vendors and function identically to any other flatpack, simply use a multitool on them to deploy the IV stand.
+  
+  <Box>
+    <GuideEntityEmbed Entity="CMIV" State="Unhooked" Caption="IV Stand"/>
+  </Box>
+
+  - IV Stand Injecting
   In order to make proper use of IV Stands, you must first
   
-  Toggle Inject Button
+  - Toggle Inject Button
 
   While an Iv is injected inside of a pateint, it is possible for the IV needle itself to rip out of a patient's arm. This occurs when an IV stand or Patient move to far away from one another.
   
@@ -35,13 +37,17 @@
   ## Summary
 
   - Blood bags are able to store 120 Units of any reagent.
-  - Both IV Stands and Blood Bags inject into the blood stream, not the chemical stream
+  - Both IV Stands and Blood Bags inject into the blood stream, not the chemical stream.
   - When used on a patient blood bags will slowly inject a patient with their contained reagents, including mixtures.
   - Empty blood bags can be filled using any injector (Ex: Syringes/Hyposprays) or IV Stands.
   - IV Stands can draw or inject from a patient.
-
-  Should include a table of types of blood to species, ex:
-  Red Blood: Humans, Vulpkanin
-  Sap Blood: Diona
   
+  Below is a table for the different types of blood and what species they corrolate to:
+  - [color=#7a8bf2]Ammonia Blood[/color]: Vox, Avali
+  - [color=#2135ab]Copper Blood[/color]: Arachnids
+  - [color=#808A51]Insect Blood[/color]: Moths
+  - [color=#ac1818]Red Blood[/color]: Humans, Dwarfs, Reptilians, Vulpkanins
+  - [color=#cd7314]Sap Blood[/color]: Dionae
+  - [color=#2cf274]Slime[/color]: Slimes
+  - [color=#00b8f5]Synthetic Blood[/color]: Any Synthetic Beings (Excluding Borgs and Station AI)
 </Document>

--- a/Resources/ServerInfo/Guidebook/_Umbra/Rmcmedical.xml
+++ b/Resources/ServerInfo/Guidebook/_Umbra/Rmcmedical.xml
@@ -5,8 +5,9 @@
     <GuideEntityEmbed Entity="CMBloodPack" Caption="Standard Blood Bag"/>
   </Box>
 
-  Blood bags can store 120 Units of any reagent, but can only be manually filled through injectors (Ex: Syringes, Hypospray, IV Stands).
- - Blood bags can inject any chemical they store.
+  Blood bags can store [color=#a4885c]120 Units[/color] of any reagent, but can only be manually filled through injectors (Ex: Syringes, Hypospray, IV Stands).
+
+  Blood bags can inject any chemical they can store, this includes mixtures.
 
   ## IV Stands
 
@@ -23,15 +24,15 @@
 
   Once an IV Stand has been deplyoed, it will need a blood pack insterted into it before it can serve any use. IV Stands will take a blood bag wether it is filled or empty.
 
-  Most commonly, you will insert a filled pack. This will allow the IV stand to inject the contents of the blood pack into your patient's chemical stream, including mixtures.
-
+  Most commonly, a filled blood pack will be inserted. This will allow the IV stand to inject the contents of the blood pack into the patient's chemical stream, including types of mixtures.
+  
   Alternatively, IV stands can store empty blood packs. By using the "Toggle Inject" verb, the IV stand will draw from the patient's blood stream. This will slowly drain the patient's bloodstream contents and fill the IV Stand's blood pack.
 
-  While an Iv is injected inside of a pateint, it is possible for the IV needle itself to rip out of a patient's arm. This occurs when an IV stand and/or Patient move to far away from one another.
+  While an IV is injected inside of a pateint, it is possible for the IV needle itself to rip out of a patient's arm. This occurs when an IV stand and/or Patient move to far away from one another.
 
   ## Summary
 
-  - Blood bags are able to store 120 Units of any reagent.
+  - Blood bags are able to store [color=#a4885c]120 Units[/color] of any reagent.
   - Both IV Stands and Blood Bags inject into the chemical stream, but draw from the blood stream.
   - When used on a patient blood bags will slowly inject a patient with their contained reagents, including mixtures.
   - Empty blood bags can be filled using any injector (Ex: Syringes/Hyposprays) or IV Stands.

--- a/Resources/ServerInfo/Guidebook/_Umbra/Rmcmedical.xml
+++ b/Resources/ServerInfo/Guidebook/_Umbra/Rmcmedical.xml
@@ -34,5 +34,6 @@
   - Blood bags are able to store 300 Units of any reagent.
   - When used on a patient blood bags will slowly inject a patient with their contained reagents, including mixtures.
   - Empty blood bags can be filled using any injector (Ex: Syringes/Hyposprays) or IV Stands.
+  - IV Stands can draw or inject from a patient.
 
 </Document>

--- a/Resources/ServerInfo/Guidebook/_Umbra/Rmcmedical.xml
+++ b/Resources/ServerInfo/Guidebook/_Umbra/Rmcmedical.xml
@@ -1,0 +1,21 @@
+<Document>
+  # Overview
+
+  ## Blood Bags
+
+  <Box>
+    <GuideEntityEmbed Entity="CMBloodPack" Caption="Standard Blood Bag"/>
+  </Box>
+
+  ## IV Stands
+
+  <Box>
+    <GuideEntityEmbed Entity="CMIV" State="Unhooked" Caption="Standard IV Stand"/>
+  </Box>
+
+  Adapted to live in cold envinronments, their bodies are capable of handling extremely cold temperatures. Their temperature range is
+  [color=#12ABE8] approximately -50C to -35C[/color]. Additionally, due to their traditionally smaller stature [color=#ffa500]
+  they are 5% less dense than the average species[/color] meaning they are slightly more susceptible to being shoved over
+  and its more difficult for them to pull objects.
+
+</Document>

--- a/Resources/ServerInfo/Guidebook/_Umbra/Rmcmedical.xml
+++ b/Resources/ServerInfo/Guidebook/_Umbra/Rmcmedical.xml
@@ -9,9 +9,10 @@
   </Box>
 
   What blood bags do
-  Blood bags store 300U
+  Blood bags store 120U
   List of blood variants and what species they coorospond to
   Blood bags can inject any chemical they store.
+  Blood bags inject into a patient's blood stream, not chemical stream.
 
   ## IV Stands
 
@@ -29,11 +30,18 @@
   
   IV Stands are also capable of drawing from a patient. This will slowly drain the patient of their bloodstream's content and fill the IV Stand's bloodbag.
 
+  IV Stands inject into a patient's blood stream, not chemical stream.
+
   ## Summary
 
-  - Blood bags are able to store 300 Units of any reagent.
+  - Blood bags are able to store 120 Units of any reagent.
+  - Both IV Stands and Blood Bags inject into the blood stream, not the chemical stream
   - When used on a patient blood bags will slowly inject a patient with their contained reagents, including mixtures.
   - Empty blood bags can be filled using any injector (Ex: Syringes/Hyposprays) or IV Stands.
   - IV Stands can draw or inject from a patient.
 
+  Should include a table of types of blood to species, ex:
+  Red Blood: Humans, Vulpkanin
+  Sap Blood: Diona
+  
 </Document>


### PR DESCRIPTION
## About the PR
Fix Namespacing in _RMC files (_RMC14 -> _RMC)
Blood bag storage nerfed (300u -> 120u) 
Medical fills (Belts, Cargo crates, etc) now spawn with the correct blood packs.
Medical Borgs now spawn with a empty blood pack for them to fill as needed.
Guidebook entry explaining IV stands and blood packs
Blood bags for default species blood (3 of each in every Nanomed)
Wall Nanomeds have 1 IV stand flatpack.
Generic Code Cleanup (Removing commented out segments and unneeded TODOs)
IV stands and blood packs no longer can attempt to attach to any entity, it now checks for entities that have the `MindContainerComponent`.

TODO:
Flush out medical borgs more with this system.
Create a new toxin, similar to heart breaker (but not), for when the wrong blood type is injected. (Something something may prevent vampire rp or weird drinks.. ideas?)
Some way for medical to acquire more blood without blood drives. (Cargo Orders + "Crafting"?)
IVs and Bloodbags should inject into the chem stream, unless its blood which should then go into the bloodstream.
Ensure the guidebook entry is accurate and understandable.

## Why / Balance
TODO

## Technical details
TODO

## Media
TODO

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines.
- [x] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
TODO

**Changelog**
TODO
