### PR TITLE
Disabled Hostile Unknown Shuttles

### DIFF
--- a/Resources/Prototypes/GameRules/roundstart.yml
+++ b/Resources/Prototypes/GameRules/roundstart.yml
@@ -294,8 +294,8 @@
         tableId: UnknownShuttlesFriendlyTable
       - !type:NestedSelector
         tableId: UnknownShuttlesFreelanceTable
-      - !type:NestedSelector
-        tableId: UnknownShuttlesHostileTable
+      # - !type:NestedSelector # Umbra: Disable.
+      #   tableId: UnknownShuttlesHostileTable
 
 - type: entity
   id: BasicStationEventScheduler


### PR DESCRIPTION
## About the PR
Disables all hostile unknown shuttle events. This prevents syndicate assault teams from spawning even with their super low chance.

## Why / Balance
I don't think we want this, especially during Unscheduled rounds. 

