### PR TITLE
Port RMC14's "Set-Pose"

### DIFF
--- a/Content.Client/_RMC/Examine/RMCSetPoseSystem.cs
+++ b/Content.Client/_RMC/Examine/RMCSetPoseSystem.cs
@@ -1,0 +1,5 @@
+using Content.Shared._RMC.Examine.Pose;
+
+namespace Content.Client._RMC.Examine;
+
+public sealed class RMCSetPoseSystem : SharedRMCSetPoseSystem;

--- a/Content.Server/_RMC/Examine/RMCSetPoseSystem.cs
+++ b/Content.Server/_RMC/Examine/RMCSetPoseSystem.cs
@@ -26,7 +26,7 @@ public sealed class RMCSetPoseSystem : SharedRMCSetPoseSystem
             {
                 if (pose.Length > 1000)
                     pose = pose[..999];
-                _adminLog.Add(LogType.RMCSetPose, $"{ToPrettyString(ent)} set their pose to {pose}");
+                _adminLog.Add(LogType.Verb, $"{ToPrettyString(ent)} set their pose to {pose}");
                 ent.Comp.Pose = pose;
                 Dirty(ent);
             }

--- a/Content.Server/_RMC/Examine/RMCSetPoseSystem.cs
+++ b/Content.Server/_RMC/Examine/RMCSetPoseSystem.cs
@@ -1,0 +1,49 @@
+using Content.Server.Administration;
+using Content.Shared._RMC.Examine.Pose;
+using Content.Shared.Actions;
+using Content.Shared.Verbs;
+using Robust.Shared.Player;
+using Robust.Shared.Utility;
+
+namespace Content.Server._RMC.Examine;
+
+public sealed class RMCSetPoseSystem : SharedRMCSetPoseSystem
+{
+    [Dependency] private readonly QuickDialogSystem _quickDialog = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<RMCSetPoseComponent, GetVerbsEvent<Verb>>(OnSetPoseGetVerbs);
+    }
+
+    private void OnSetPoseGetVerbs(Entity<RMCSetPoseComponent> ent, ref GetVerbsEvent<Verb> args)
+    {
+        if (!args.CanInteract)
+            return;
+
+        if (args.User != args.Target)
+            return;
+
+        if (!TryComp<ActorComponent>(ent, out var actor))
+            return;
+
+        var setPosePrompt = Loc.GetString("rmc-set-pose-dialog", ("ent", ent));
+
+        Verb verb = new()
+        {
+            Text = Loc.GetString("rmc-set-pose-title"),
+            Icon = new SpriteSpecifier.Texture(new("/Textures/Interface/character.svg.192dpi.png")),
+            Priority = -5,
+            Act = () => _quickDialog.OpenDialog(actor.PlayerSession, Loc.GetString("rmc-set-pose-title"), setPosePrompt,
+            (string pose) =>
+            {
+                ent.Comp.Pose = pose;
+                Dirty(ent);
+            })
+        };
+
+        args.Verbs.Add(verb);
+    }
+}

--- a/Content.Server/_RMC/Examine/RMCSetPoseSystem.cs
+++ b/Content.Server/_RMC/Examine/RMCSetPoseSystem.cs
@@ -1,49 +1,35 @@
 using Content.Server.Administration;
 using Content.Shared._RMC.Examine.Pose;
-using Content.Shared.Actions;
-using Content.Shared.Verbs;
+using Content.Shared.Administration.Logs;
+using Content.Shared.Database;
 using Robust.Shared.Player;
-using Robust.Shared.Utility;
 
 namespace Content.Server._RMC.Examine;
 
 public sealed class RMCSetPoseSystem : SharedRMCSetPoseSystem
 {
+    [Dependency] private readonly ISharedAdminLogManager _adminLog = default!;
     [Dependency] private readonly QuickDialogSystem _quickDialog = default!;
 
-    public override void Initialize()
+    protected override void SetPose(Entity<RMCSetPoseComponent> ent)
     {
-        base.Initialize();
-
-        SubscribeLocalEvent<RMCSetPoseComponent, GetVerbsEvent<Verb>>(OnSetPoseGetVerbs);
-    }
-
-    private void OnSetPoseGetVerbs(Entity<RMCSetPoseComponent> ent, ref GetVerbsEvent<Verb> args)
-    {
-        if (!args.CanInteract)
-            return;
-
-        if (args.User != args.Target)
-            return;
+        base.SetPose(ent);
 
         if (!TryComp<ActorComponent>(ent, out var actor))
             return;
 
         var setPosePrompt = Loc.GetString("rmc-set-pose-dialog", ("ent", ent));
-
-        Verb verb = new()
-        {
-            Text = Loc.GetString("rmc-set-pose-title"),
-            Icon = new SpriteSpecifier.Texture(new("/Textures/Interface/character.svg.192dpi.png")),
-            Priority = -5,
-            Act = () => _quickDialog.OpenDialog(actor.PlayerSession, Loc.GetString("rmc-set-pose-title"), setPosePrompt,
+        _quickDialog.OpenDialog(actor.PlayerSession,
+            Loc.GetString("rmc-set-pose-title"),
+            setPosePrompt,
             (string pose) =>
             {
+                if (pose.Length > 1000)
+                    pose = pose[..999];
+                _adminLog.Add(LogType.RMCSetPose, $"{ToPrettyString(ent)} set their pose to {pose}");
                 ent.Comp.Pose = pose;
                 Dirty(ent);
-            })
-        };
-
-        args.Verbs.Add(verb);
+            }
+        );
     }
 }

--- a/Content.Shared/_RMC/Examine/Pose/RMCSetPoseComponent.cs
+++ b/Content.Shared/_RMC/Examine/Pose/RMCSetPoseComponent.cs
@@ -1,0 +1,15 @@
+using Robust.Shared.GameStates;
+using Robust.Shared.Prototypes;
+
+namespace Content.Shared._RMC.Examine.Pose;
+
+/// <summary>
+/// Flavour text when this entity is examined. Can be set with an action.
+/// </summary>
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+[Access(typeof(SharedRMCSetPoseSystem))]
+public sealed partial class RMCSetPoseComponent : Component
+{
+    [DataField, AutoNetworkedField]
+    public string Pose = string.Empty;
+}

--- a/Content.Shared/_RMC/Examine/Pose/SharedRMCSetPoseSystem.cs
+++ b/Content.Shared/_RMC/Examine/Pose/SharedRMCSetPoseSystem.cs
@@ -1,19 +1,38 @@
-using Content.Shared.Actions;
 using Content.Shared.Examine;
 using Content.Shared.Mobs;
+using Content.Shared.Verbs;
+using Robust.Shared.Utility;
 
 namespace Content.Shared._RMC.Examine.Pose;
 
 public abstract class SharedRMCSetPoseSystem : EntitySystem
 {
-    [Dependency] private readonly SharedActionsSystem _actions = default!;
-
     public override void Initialize()
     {
         base.Initialize();
 
+        SubscribeLocalEvent<RMCSetPoseComponent, GetVerbsEvent<Verb>>(OnSetPoseGetVerbs);
         SubscribeLocalEvent<RMCSetPoseComponent, ExaminedEvent>(OnExamine);
         SubscribeLocalEvent<RMCSetPoseComponent, MobStateChangedEvent>(OnMobStateChanged);
+    }
+
+    private void OnSetPoseGetVerbs(Entity<RMCSetPoseComponent> ent, ref GetVerbsEvent<Verb> args)
+    {
+        if (!args.CanInteract)
+            return;
+
+        if (args.User != args.Target)
+            return;
+
+        Verb verb = new()
+        {
+            Text = Loc.GetString("rmc-set-pose-title"),
+            Icon = new SpriteSpecifier.Texture(new ResPath("/Textures/Interface/character.svg.192dpi.png")),
+            Priority = -5,
+            Act = () => SetPose(ent),
+        };
+
+        args.Verbs.Add(verb);
     }
 
     private void OnExamine(Entity<RMCSetPoseComponent> ent, ref ExaminedEvent args)
@@ -37,5 +56,9 @@ public abstract class SharedRMCSetPoseSystem : EntitySystem
 
         ent.Comp.Pose = string.Empty; // reset the pose on death/crit
         Dirty(ent);
+    }
+
+    protected virtual void SetPose(Entity<RMCSetPoseComponent> ent)
+    {
     }
 }

--- a/Content.Shared/_RMC/Examine/Pose/SharedRMCSetPoseSystem.cs
+++ b/Content.Shared/_RMC/Examine/Pose/SharedRMCSetPoseSystem.cs
@@ -1,0 +1,41 @@
+using Content.Shared.Actions;
+using Content.Shared.Examine;
+using Content.Shared.Mobs;
+
+namespace Content.Shared._RMC.Examine.Pose;
+
+public abstract class SharedRMCSetPoseSystem : EntitySystem
+{
+    [Dependency] private readonly SharedActionsSystem _actions = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<RMCSetPoseComponent, ExaminedEvent>(OnExamine);
+        SubscribeLocalEvent<RMCSetPoseComponent, MobStateChangedEvent>(OnMobStateChanged);
+    }
+
+    private void OnExamine(Entity<RMCSetPoseComponent> ent, ref ExaminedEvent args)
+    {
+        var comp = ent.Comp;
+
+        if (comp.Pose.Trim() == string.Empty)
+            return;
+
+        using (args.PushGroup(nameof(RMCSetPoseComponent)))
+        {
+            var pose = Loc.GetString("rmc-set-pose-examined", ("ent", ent), ("pose", comp.Pose));
+            args.PushMarkup(pose, -5);
+        }
+    }
+
+    private void OnMobStateChanged(Entity<RMCSetPoseComponent> ent, ref MobStateChangedEvent args)
+    {
+        if (args.NewMobState == MobState.Alive)
+            return;
+
+        ent.Comp.Pose = string.Empty; // reset the pose on death/crit
+        Dirty(ent);
+    }
+}

--- a/Resources/Locale/en-US/_RMC/pose/set-pose.ftl
+++ b/Resources/Locale/en-US/_RMC/pose/set-pose.ftl
@@ -1,0 +1,3 @@
+rmc-set-pose-examined = [color=lightblue][bold]{ CAPITALIZE(SUBJECT($ent)) } { CONJUGATE-BE($ent) } {$pose}[/bold][/color]
+rmc-set-pose-dialog = This is {$ent}. { CAPITALIZE(SUBJECT($ent)) } { CONJUGATE-BE($ent) }...
+rmc-set-pose-title = Set Pose

--- a/Resources/Prototypes/Entities/Mobs/Species/base.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/base.yml
@@ -283,6 +283,7 @@
     alternateState: Standing
   - type: LayEmote # CD Change, laying down emote
   - type: CPRPerformer # Umbra Change, all species can provide CPR.
+  - type: RMCSetPose # RMC Change, all species can set their pose through right clicking on themselves and selecting the "Set Pose" verb.
 
 - type: entity
   save: false


### PR DESCRIPTION
## About the PR
Ports the following RMC PRs:
https://github.com/RMC-14/RMC-14/pull/4682
https://github.com/RMC-14/RMC-14/pull/6048

## Why / Balance
Good HRP Mechanic. Allows for better understanding of characters from the exact moment you see them, helps with immersion and alike.

## Technical details
Adds another component to species base. The verb inputs a string and then adds it to the same entities examine text.

### Dream Update (One day..)
- Mention somewhere in the guidebook how this works.
- Remove from verb menu (Alt: make a "RP" section of the verb menu depending on how many of these we get) and make it an action.
- Easier way to clear the examine text.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
RMC-14's "Set-Pose" mechanic has been ported. Simply right click on yourself and input whatever text you wish (Such as "has their arms folded." and it will display when your character is examined. If you wish to clear this text, simply open the action again and enter an empty text box.
