### PR TITLE
Added: Claimable Containers and ID Claim Holders

### DIFF
--- a/Content.Shared/Lock/LockComponent.cs
+++ b/Content.Shared/Lock/LockComponent.cs
@@ -97,7 +97,7 @@ public record struct UserLockToggleAttemptEvent(EntityUid Target, bool Silent = 
 /// Event raised on a lock after it has been toggled.
 /// </summary>
 [ByRefEvent]
-public readonly record struct LockToggledEvent(bool Locked);
+public readonly record struct LockToggledEvent(bool Locked, EntityUid? User);
 
 /// <summary>
 /// Used to lock a lockable entity that has a lock time configured.

--- a/Content.Shared/Lock/LockSystem.cs
+++ b/Content.Shared/Lock/LockSystem.cs
@@ -157,7 +157,7 @@ public sealed class LockSystem : EntitySystem
         _appearanceSystem.SetData(uid, LockVisuals.Locked, true);
         Dirty(uid, lockComp);
 
-        var ev = new LockToggledEvent(true);
+        var ev = new LockToggledEvent(true, user);
         RaiseLocalEvent(uid, ref ev, true);
     }
 
@@ -187,7 +187,7 @@ public sealed class LockSystem : EntitySystem
         _appearanceSystem.SetData(uid, LockVisuals.Locked, false);
         Dirty(uid, lockComp);
 
-        var ev = new LockToggledEvent(false);
+        var ev = new LockToggledEvent(false, user);
         RaiseLocalEvent(uid, ref ev, true);
     }
 
@@ -308,7 +308,7 @@ public sealed class LockSystem : EntitySystem
         _appearanceSystem.SetData(uid, LockVisuals.Locked, false);
         Dirty(uid, component);
 
-        var ev = new LockToggledEvent(false);
+        var ev = new LockToggledEvent(false, null);
         RaiseLocalEvent(uid, ref ev, true);
 
         args.Repeatable = true;

--- a/Content.Shared/_Umbra/Container/ClaimableContainerComponent.cs
+++ b/Content.Shared/_Umbra/Container/ClaimableContainerComponent.cs
@@ -1,0 +1,25 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared._Umbra.Container;
+
+[RegisterComponent, NetworkedComponent]
+public sealed partial class ClaimableContainerComponent : Component
+{
+    /// <summary>
+    /// TODO: Summaries
+    /// </summary>
+    [DataField]
+    public bool Claimable = true;
+
+    /// <summary>
+    /// TODO: Summaries
+    /// </summary>
+    [DataField]
+    public EntityUid IDClaim;
+}
+
+/// <summary>
+/// Event raised on a lock after it has been toggled.
+/// </summary>
+[ByRefEvent]
+public record struct AttemptClaimContainer(EntityUid IdNumber);

--- a/Content.Shared/_Umbra/Container/ClaimableContainerSystem.cs
+++ b/Content.Shared/_Umbra/Container/ClaimableContainerSystem.cs
@@ -1,0 +1,29 @@
+using Content.Shared.Lock;
+
+
+namespace Content.Shared._Umbra.Container;
+
+
+public sealed class ClaimableContainerSystem : EntitySystem
+{
+    /// <inheritdoc />
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<ClaimableContainerComponent, LockToggledEvent>(OnActivated);
+
+    }
+
+    private void OnActivated(EntityUid uid, ClaimableContainerComponent component, ref LockToggledEvent args)
+    {
+        // Locker has been either Locked, or Unlocked. Attempt to claim the locker with the persons ID.
+        Log.Debug("among us trap beat 100 hour edition (real)");
+
+        var ev = new AttemptClaimContainer();
+        RaiseLocalEvent(uid, ref ev, true);
+
+        ev.IdNumber = component.IDClaim;
+    }
+}
+

--- a/Content.Shared/_Umbra/Container/ClaimableContainerSystem.cs
+++ b/Content.Shared/_Umbra/Container/ClaimableContainerSystem.cs
@@ -1,3 +1,7 @@
+using System.Diagnostics;
+using Content.Shared.Access.Systems;
+using Content.Shared.Hands.EntitySystems;
+using Content.Shared.Inventory;
 using Content.Shared.Lock;
 
 
@@ -6,6 +10,10 @@ namespace Content.Shared._Umbra.Container;
 
 public sealed class ClaimableContainerSystem : EntitySystem
 {
+    [Dependency] private readonly AccessReaderSystem _accessReader = default!;
+    [Dependency] private readonly SharedHandsSystem _handsSystem = default!;
+    [Dependency] private readonly InventorySystem _inventorySystem = default!;
+
     /// <inheritdoc />
     public override void Initialize()
     {
@@ -17,13 +25,34 @@ public sealed class ClaimableContainerSystem : EntitySystem
 
     private void OnActivated(EntityUid uid, ClaimableContainerComponent component, ref LockToggledEvent args)
     {
-        // Locker has been either Locked, or Unlocked. Attempt to claim the locker with the persons ID.
-        Log.Debug("among us trap beat 100 hour edition (real)");
+        EntityUid user = (EntityUid)args.User!;
 
-        var ev = new AttemptClaimContainer();
-        RaiseLocalEvent(uid, ref ev, true);
+        foreach (var item in _handsSystem.EnumerateHeld(user))
+        {
+            if (user == null)
+            {
+                Log.Debug("User is Null, Something went wrong.");
+                return;
+            }
 
-        ev.IdNumber = component.IDClaim;
+            if (_accessReader.IsAllowed(user, uid))
+            {
+                Log.Debug(user + " " + uid + " claimed");
+            }
+        }
+
+//        // maybe its inside an inventory slot?
+//        if (_inventorySystem.TryGetSlotEntity(uid, "id", out var idUid))
+//        {
+//            items.Add(idUid.Value);
+//        }
+//
+//        return items.Any();
     }
+
+//    private void ClaimContainer(target)
+//    {
+//
+//    }
 }
 

--- a/Content.Shared/_Umbra/Container/ContainerClaimHolderComponent.cs
+++ b/Content.Shared/_Umbra/Container/ContainerClaimHolderComponent.cs
@@ -1,0 +1,13 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared._Umbra.Container;
+
+[RegisterComponent, NetworkedComponent]
+public sealed partial class ContainerClaimHolderComponent : Component
+{
+    /// <summary>
+    /// TODO: Summaries
+    /// </summary>
+    [DataField]
+    public EntityUid ClaimIDNumber;
+}

--- a/Content.Shared/_Umbra/Container/ContainerClaimHolderSystem.cs
+++ b/Content.Shared/_Umbra/Container/ContainerClaimHolderSystem.cs
@@ -14,7 +14,7 @@ public sealed partial class ContainerClaimHolderSystem : EntitySystem
 
     private void OnAttemptClaimContainer(EntityUid uid, ClaimableContainerComponent component, ref AttemptClaimContainer args)
     {
-        Log.Debug(uid + " IM FUCKING SCREAMING");
+        Log.Debug(uid + " IM FUCKING SCREAMING " + component.Owner);
 //        args.IdNumber = uid.
     }
 }

--- a/Content.Shared/_Umbra/Container/ContainerClaimHolderSystem.cs
+++ b/Content.Shared/_Umbra/Container/ContainerClaimHolderSystem.cs
@@ -1,0 +1,20 @@
+namespace Content.Shared._Umbra.Container;
+
+public sealed partial class ContainerClaimHolderSystem : EntitySystem
+{
+    /// <inheritdoc />
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<ClaimableContainerComponent, AttemptClaimContainer>(OnAttemptClaimContainer);
+
+
+    }
+
+    private void OnAttemptClaimContainer(EntityUid uid, ClaimableContainerComponent component, ref AttemptClaimContainer args)
+    {
+        Log.Debug(uid + " IM FUCKING SCREAMING");
+//        args.IdNumber = uid.
+    }
+}

--- a/Resources/Prototypes/Entities/Objects/Misc/identification_cards.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/identification_cards.yml
@@ -25,6 +25,7 @@
     - WhitelistChameleonIdCard
   - type: StealTarget
     stealGroup: IDCard
+  - type: ContainerClaimHolder
 
 #IDs with layers
 

--- a/Resources/Prototypes/Entities/Structures/Storage/Closets/Lockers/base_structurelockers.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Closets/Lockers/base_structurelockers.yml
@@ -54,6 +54,7 @@
     node: done
     containers:
     - entity_storage
+  - type: ClaimableContainer
 
 - type: entity
   id: LockerBaseSecure


### PR DESCRIPTION
## About the PR
Adding the ability for characters with an ID to claim a locker using an ID. Once a locker is claimed, anyone else trying to open the locker will receive a warning that it isn't theres, and would give a warning that can be bypassed by attempting to open it again. Potentially allow lockers to remain locked and unopenable in the future as well if it isn't yours.

Command will also have the ability to bypass this restriction, but also allow their IDs to wipe claims on lockers. IDs can have their claims removed by the ID Access Computer in case their locker was claimed by someone else, or was destroyed.

## Why / Balance
Allows players to feel like they can store their own things in a locker and to leave other peoples belongings alone. Make the workplace actually feel more like a workplace.

## Technical details
**AUGHHHHHHHHHHHHHHH**

## Media
[TODO when Working]

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [ ] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [ ] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
[TODO]

**Changelog**
[TODO]
