### PR TITLE
Fix Master RSI Fail (Add Missing Vox State in Meta)

### DIFF
--- a/Resources/Textures/Clothing/Mask/gassyndicate.rsi/meta.json
+++ b/Resources/Textures/Clothing/Mask/gassyndicate.rsi/meta.json
@@ -29,6 +29,16 @@
             "directions": 4
         },
         {
+            "name": "equipped-MASK-vox",
+            "directions": 4,
+            "delays": [
+                [ 0.5, 0.5, 0.5 ],
+                [ 0.5, 0.5, 0.5 ],
+                [ 0.5, 0.5, 0.5 ],
+                [ 0.5, 0.5, 0.5 ]
+            ]
+        },
+        {
             "name": "equipped-MASK-vulpkanin",
             "directions": 4,
             "delays": [


### PR DESCRIPTION
## About the PR
Re-Added `equipped-MASK-vox` to the meta.json, pulled from wizden's meta file to make the test fail on master stop.