### PR TITLE
Port CD Mime Writing

### DIFF
--- a/Resources/Prototypes/Roles/Jobs/Civilian/mime.yml
+++ b/Resources/Prototypes/Roles/Jobs/Civilian/mime.yml
@@ -13,7 +13,7 @@
   - !type:AddComponentSpecial
     components:
     - type: MimePowers
-      preventWriting: true
+      preventWriting: false # CD, allows Mimes to write!!
     - type: FrenchAccent
 
 - type: startingGear


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Ports [CD PR 603](https://github.com/cosmatic-drift-14/cosmatic-drift/pull/603) allowing mimes to write, which is a single line change.

## Why / Balance
The removal of mimes writing was caused by LRP behavior observed by wizard's den, we will have no such issues here and this feels like a really bad way of limiting communication. Mimes have an oath of silence, but their hands still work.

**Changelog**
Mimes are able to write again.
