### PR TITLE
increase time it takes for holopad to hang up during idle call activity

### DIFF
--- a/Content.Shared/Telephone/TelephoneComponent.cs
+++ b/Content.Shared/Telephone/TelephoneComponent.cs
@@ -20,7 +20,7 @@ public sealed partial class TelephoneComponent : Component
     /// Sets how long the telephone can remain idle in-call before it automatically hangs up
     /// </summary>
     [DataField]
-    public float IdlingTimeout = 600; // Umbra edit
+    public float IdlingTimeout = 600; // Umbra edit - 10 Minutes
 
     /// <summary>
     /// Sets how long the telephone will stay in the hanging up state before return to idle

--- a/Content.Shared/Telephone/TelephoneComponent.cs
+++ b/Content.Shared/Telephone/TelephoneComponent.cs
@@ -20,7 +20,7 @@ public sealed partial class TelephoneComponent : Component
     /// Sets how long the telephone can remain idle in-call before it automatically hangs up
     /// </summary>
     [DataField]
-    public float IdlingTimeout = 60;
+    public float IdlingTimeout = 600; // Umbra edit
 
     /// <summary>
     /// Sets how long the telephone will stay in the hanging up state before return to idle


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
changed the default time it takes for a call (holopad) to hang up without any activity from one minute to ten minutes

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
whenever making a call as an AI on a holopad, there are multiple instances where you will be listening for your call recipient without any input from your for a while, causing you to get kicked out of the call during the middle of conversation, which is frustrating - this might be an issue for normal holopad calls as well, but AI is the main use case i've experience

TelephoneComponent is literally only being in use by holopads at the moment so it should only affect this, however this should keep things in check in the future as well should any more content get added that uses TelephoneComponent

## Technical details
<!-- Summary of code changes for easier review. -->
singular C# variable edit in TelephoneComponent.cs due to there being no place that IdlingTimeout is set in YAML

no media because it would just be the dev environment with nothing else for 10 minutes

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: holopads now hang up after ten minutes of idle activity, up from one
