### PR TITLE
Change random_characters to false for development builds

### DIFF
--- a/Resources/ConfigPresets/Build/development.toml
+++ b/Resources/ConfigPresets/Build/development.toml
@@ -39,5 +39,6 @@ preload_grids = false
 see_own_notes = true
 
 [ic]
-random_characters = true
+# Umbra, random characters to false.
+random_characters = false
 random_species_weights = ""


### PR DESCRIPTION
## About the PR
In the development cvars, changed the `ic.random_characters` CVAR to false.

## Why / Balance
For the development we do and PRs we frequently review, this CVAR was annoying to work around. We shouldn't have to set this to false just to test personal items quickly.

## Breaking changes
For development builds, the `ic.random_characters` CVAR is now false by default.

**Changelog**
For development builds, the `ic.random_characters` CVAR is now false by default.