### PR TITLE
removed duplicated entry since loadout handles sec glasses

### DIFF
--- a/Resources/Prototypes/_CD/Loadouts/Jobs/Security/security_officer.yml
+++ b/Resources/Prototypes/_CD/Loadouts/Jobs/Security/security_officer.yml
@@ -3,11 +3,6 @@
   equipment:
     eyes: ClothingEyesGlassesSecurity
 
-- type: startingGear
-  id: EyesGlassesSecurity
-  equipment:
-    eyes: ClothingEyesGlassesSecurity
-
 - type: loadout
   id: EyesHudSecurity
   equipment:


### PR DESCRIPTION
## About the PR
Removes duplicated entry that was causing security glasses to be forced as starting gear, but also as a loadout.

This now makes it so the loadout primarily handles the placement of glasses on security members

## Why / Balance
Bugfix

## Technical details
removed startingGear entry in security_officer.yml

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [ ] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [ ] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
N/A

**Changelog**
Security Glasses should no longer randomly spawn at spawnpoints when someone spawns as a security member.