### PR TITLE
Reverts Plushie Attack Speed

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Fun/plushies.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/plushies.yml
@@ -21,7 +21,6 @@
   - type: UseDelay
     delay: 1.0
   - type: MeleeWeapon
-    attackRate: 0.333
     wideAnimationRotation: 180
     soundHit: *BasePlushieSound
     damage:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Plushie :)

## Why / Balance
We have less players so we don't need to deal with plushie volume abuse.

## Technical details
Removed attack speed modifier that was added in the Plushie change PR

## Media
N/A

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
N/A

**Changelog**
Plushies attack speed is back to how they normally are for 1 second each.
