### PR TITLE
Add Raised by [species] and Voice of [species] character traits - Harmony Port

### DIFF
--- a/Content.Server/Traits/TraitSystem.cs
+++ b/Content.Server/Traits/TraitSystem.cs
@@ -45,7 +45,7 @@ public sealed class TraitSystem : EntitySystem
                 continue;
 
             // Add all components required by the prototype
-            EntityManager.AddComponents(args.Mob, traitPrototype.Components, false);
+            EntityManager.AddComponents(args.Mob, traitPrototype.Components, traitPrototype.ReplaceComponents); // Harmony change. See TraitPrototype.cs
 
             // Add item required by the trait
             if (traitPrototype.TraitGear == null)

--- a/Content.Shared/Traits/TraitPrototype.cs
+++ b/Content.Shared/Traits/TraitPrototype.cs
@@ -60,4 +60,10 @@ public sealed partial class TraitPrototype : IPrototype
     /// </summary>
     [DataField]
     public ProtoId<TraitCategoryPrototype>? Category;
+
+    /// <summary>
+    /// Allows you to replace existing components. Harmony change.
+    /// </summary>
+    [DataField]
+    public bool ReplaceComponents = false;
 }

--- a/Resources/Locale/en-US/_Harmony/traits/traits.ftl
+++ b/Resources/Locale/en-US/_Harmony/traits/traits.ftl
@@ -1,0 +1,47 @@
+trait-raisedbyarachnids-name = Raised by Arachnids
+trait-raisedbyarachnids-desc = You've lived with Arachnids for so long that you sound like them. (Replace speech sounds and verbs)
+
+trait-raisedbydiona-name = Raised by Diona
+trait-raisedbydiona-desc = You've lived with Diona for so long that you sound like them. (Replace speech sounds and verbs)
+
+trait-raisedbydwarfs-name = Raised by Dwarfs
+trait-raisedbydwarfs-desc = You've lived with Dwarfs for so long that you sound like them. (Replace speech sounds and verbs)
+
+trait-raisedbyhumans-name = Raised by Humans
+trait-raisedbyhumans-desc = You've lived with Humans for so long that you sound like them. (Replace speech sounds and verbs)
+
+trait-raisedbymoths-name = Raised by Moths
+trait-raisedbymoths-desc = You've lived with Moths for so long that you sound like them. (Replace speech sounds and verbs)
+
+trait-raisedbyreptilians-name = Raised by Reptilians
+trait-raisedbyreptilians-desc = You've lived with Reptilians for so long that you sound like them. (Replace speech sounds and verbs)
+
+trait-raisedbyslimes-name = Raised by Slimes
+trait-raisedbyslimes-desc = You've lived with Slimes for so long that you sound like them. (Replace speech sounds and verbs)
+
+trait-raisedbyvox-name = Raised by Vox
+trait-raisedbyvox-desc = You've lived with Vox for so long that you sound like them. (Replace speech sounds and verbs)
+
+trait-arachnidvocals-name = Voice of Arachnid
+trait-arachnidvocals-desc = You are somehow able to fully mimic Arachnid speech. (Replace speech sounds, verbs, emotes and emote sounds)
+
+trait-dionavocals-name = Voice of Diona
+trait-dionavocals-desc = You are somehow able to fully mimic Diona speech. (Replace speech sounds, verbs, and emote sounds)
+
+trait-dwarfvocals-name = Voice of Dwarf
+trait-dwarfvocals-desc = You are somehow able to fully mimic Dwarf speech. (Replace speech sounds, verbs, emote sounds, and accent)
+
+trait-humanvocals-name = Voice of Human
+trait-humanvocals-desc = You are somehow able to fully mimic Human speech. (Replace speech sounds, verbs, and emote sounds)
+
+trait-mothvocals-name = Voice of Moth
+trait-mothvocals-desc = You are somehow able to fully mimic Moth speech. (Replace speech sounds, verbs, emotes, emote sounds, and accent)
+
+trait-reptilianvocals-name = Voice of Reptilian
+trait-reptilianvocals-desc = You are somehow able to fully mimic Reptilian speech. (Replacesspeech sounds, verbs, emote sounds, and accent)
+
+trait-slimevocals-name = Voice of Slime
+trait-slimevocals-desc = You are somehow able to fully mimic Slime speech. (Replaces speech sounds, verbs, emotes, and emote sounds)
+
+trait-voxvocals-name = Voice of Vox
+trait-voxvocals-desc = You are somehow able to fully mimic Vox speech. (Replace speech sounds, verbs, and emote sounds)

--- a/Resources/Locale/en-US/_Umbra/preferences/ui/humanoid-profile-editor.ftl
+++ b/Resources/Locale/en-US/_Umbra/preferences/ui/humanoid-profile-editor.ftl
@@ -1,0 +1,1 @@
+trait-category-replacement-speech = Replacement Speech traits

--- a/Resources/Prototypes/_Harmony/Traits/speech.yml
+++ b/Resources/Prototypes/_Harmony/Traits/speech.yml
@@ -1,0 +1,240 @@
+# Basic speech-only replacement traits
+- type: trait
+  id: HarmonyRaisedByArachnids
+  name: trait-raisedbyarachnids-name
+  description: trait-raisedbyarachnids-desc
+  replaceComponents: true
+  cost: 1
+  category: SpeechTraits
+  components:
+    - type: Speech
+      speechVerb: Arachnid
+      speechSounds: Arachnid
+
+- type: trait
+  id: HarmonyRaisedByDiona
+  name: trait-raisedbydiona-name
+  description: trait-raisedbydiona-desc
+  replaceComponents: true
+  cost: 1
+  category: SpeechTraits
+  components:
+    - type: Speech
+      speechSounds: Alto
+      speechVerb: Plant
+
+- type: trait
+  id: HarmonyRaisedByDwarfs
+  name: trait-raisedbydwarfs-name
+  description: trait-raisedbydwarfs-desc
+  replaceComponents: true
+  cost: 1
+  category: SpeechTraits
+  components:
+    - type: Speech
+      speechSounds: Bass
+      speechVerb: Default
+
+- type: trait
+  id: HarmonyRaisedByHumans
+  name: trait-raisedbyhumans-name
+  description: trait-raisedbyhumans-desc
+  replaceComponents: true
+  cost: 1
+  category: SpeechTraits
+  components:
+    - type: Speech
+      speechSounds: Alto
+      speechVerb: Default
+
+- type: trait
+  id: HarmonyRaisedByMoths
+  name: trait-raisedbymoths-name
+  description: trait-raisedbymoths-desc
+  replaceComponents: true
+  cost: 1
+  category: SpeechTraits
+  components:
+    - type: Speech
+      speechSounds: Alto
+      speechVerb: Moth
+
+- type: trait
+  id: HarmonyRaisedByReptilians
+  name: trait-raisedbyreptilians-name
+  description: trait-raisedbyreptilians-desc
+  replaceComponents: true
+  cost: 1
+  category: SpeechTraits
+  components:
+    - type: Speech
+      speechSounds: Lizard
+      speechVerb: Reptilian
+
+- type: trait
+  id: HarmonyRaisedBySlimes
+  name: trait-raisedbyslimes-name
+  description: trait-raisedbyslimes-desc
+  replaceComponents: true
+  cost: 1
+  category: SpeechTraits
+  components:
+    - type: Speech
+      speechVerb: Slime
+      speechSounds: Slime
+
+- type: trait
+  id: HarmonyRaisedByVox
+  name: trait-raisedbyvox-name
+  description: trait-raisedbyvox-desc
+  replaceComponents: true
+  cost: 1
+  category: SpeechTraits
+  components:
+    - type: Speech
+      speechVerb: Vox
+      speechSounds: Vox
+
+# Full speech and vocal replacement traits
+- type: trait
+  id: HarmonyArachnidVocals
+  name: trait-arachnidvocals-name
+  description: trait-arachnidvocals-desc
+  replaceComponents: true
+  cost: 2
+  category: SpeechTraits
+  components:
+    - type: Speech
+      speechVerb: Arachnid
+      speechSounds: Arachnid
+      allowedEmotes: ['Click', 'Chitter']
+    - type: Vocal
+      sounds:
+        Male: UnisexArachnid
+        Female: UnisexArachnid
+        Unsexed: UnisexArachnid
+
+- type: trait
+  id: HarmonyDionaVocals
+  name: trait-dionavocals-name
+  description: trait-dionavocals-desc
+  replaceComponents: true
+  cost: 2
+  category: SpeechTraits
+  components:
+    - type: Speech
+      speechSounds: Alto
+      speechVerb: Plant
+    - type: Vocal
+      sounds:
+        Male: UnisexDiona
+        Female: UnisexDiona
+        Unsexed: UnisexDiona
+
+- type: trait
+  id: HarmonyDwarfVocals
+  name: trait-dwarfvocals-name
+  description: trait-dwarfvocals-desc
+  replaceComponents: true
+  cost: 2
+  category: SpeechTraits
+  components:
+    - type: Speech
+      speechSounds: Bass
+      speechVerb: Default
+    - type: ReplacementAccent
+      accent: dwarf
+    - type: Vocal
+      sounds:
+        Male: UnisexDwarf
+        Female: FemaleDwarf
+        Unsexed: UnisexDwarf
+
+- type: trait
+  id: HarmonyHumanVocals
+  name: trait-humanvocals-name
+  description: trait-humanvocals-desc
+  replaceComponents: true
+  cost: 2
+  category: SpeechTraits
+  components:
+    - type: Speech
+      speechSounds: Alto
+      speechVerb: Default
+    - type: Vocal
+      sounds:
+        Male: MaleHuman
+        Female: FemaleHuman
+        Unsexed: MaleHuman
+
+- type: trait
+  id: HarmonyMothsVocals
+  name: trait-mothvocals-name
+  description: trait-mothvocals-desc
+  replaceComponents: true
+  cost: 2
+  category: SpeechTraits
+  components:
+    - type: MothAccent
+    - type: Speech
+      speechSounds: Alto
+      speechVerb: Moth
+      allowedEmotes: ['Chitter', 'Squeak']
+    - type: Vocal
+      sounds:
+        Male: UnisexMoth
+        Female: UnisexMoth
+        Unsexed: UnisexMoth
+
+- type: trait
+  id: HarmonyReptilianVocals
+  name: trait-reptilianvocals-name
+  description: trait-reptilianvocals-desc
+  replaceComponents: true
+  cost: 2
+  category: SpeechTraits
+  components:
+    - type: LizardAccent
+    - type: Speech
+      speechSounds: Lizard
+      speechVerb: Reptilian
+    - type: Vocal
+      sounds:
+        Male: MaleReptilian
+        Female: FemaleReptilian
+        Unsexed: MaleReptilian
+
+- type: trait
+  id: HarmonySlimeVocals
+  name: trait-slimevocals-name
+  description: trait-slimevocals-desc
+  replaceComponents: true
+  cost: 2
+  category: SpeechTraits
+  components:
+    - type: Speech
+      speechVerb: Slime
+      speechSounds: Slime
+      allowedEmotes: ['Squish']
+    - type: Vocal
+      sounds:
+        Male: MaleSlime
+        Female: FemaleSlime
+        Unsexed: MaleSlime
+
+- type: trait
+  id: HarmonyVoxVocals
+  name: trait-voxvocals-name
+  description: trait-voxvocals-desc
+  replaceComponents: true
+  cost: 2
+  category: SpeechTraits
+  components:
+    - type: Speech
+      speechVerb: Vox
+      speechSounds: Vox
+    - type: Vocal
+      sounds:
+        Male: UnisexVox
+        Female: UnisexVox
+        Unsexed: UnisexVox

--- a/Resources/Prototypes/_Harmony/Traits/speech.yml
+++ b/Resources/Prototypes/_Harmony/Traits/speech.yml
@@ -5,7 +5,7 @@
   description: trait-raisedbyarachnids-desc
   replaceComponents: true
   cost: 1
-  category: SpeechTraits
+  category: ReplacementSpeechTraits
   components:
     - type: Speech
       speechVerb: Arachnid
@@ -17,7 +17,7 @@
   description: trait-raisedbydiona-desc
   replaceComponents: true
   cost: 1
-  category: SpeechTraits
+  category: ReplacementSpeechTraits
   components:
     - type: Speech
       speechSounds: Alto
@@ -29,7 +29,7 @@
   description: trait-raisedbydwarfs-desc
   replaceComponents: true
   cost: 1
-  category: SpeechTraits
+  category: ReplacementSpeechTraits
   components:
     - type: Speech
       speechSounds: Bass
@@ -41,7 +41,7 @@
   description: trait-raisedbyhumans-desc
   replaceComponents: true
   cost: 1
-  category: SpeechTraits
+  category: ReplacementSpeechTraits
   components:
     - type: Speech
       speechSounds: Alto
@@ -53,7 +53,7 @@
   description: trait-raisedbymoths-desc
   replaceComponents: true
   cost: 1
-  category: SpeechTraits
+  category: ReplacementSpeechTraits
   components:
     - type: Speech
       speechSounds: Alto
@@ -65,7 +65,7 @@
   description: trait-raisedbyreptilians-desc
   replaceComponents: true
   cost: 1
-  category: SpeechTraits
+  category: ReplacementSpeechTraits
   components:
     - type: Speech
       speechSounds: Lizard
@@ -77,7 +77,7 @@
   description: trait-raisedbyslimes-desc
   replaceComponents: true
   cost: 1
-  category: SpeechTraits
+  category: ReplacementSpeechTraits
   components:
     - type: Speech
       speechVerb: Slime
@@ -89,7 +89,7 @@
   description: trait-raisedbyvox-desc
   replaceComponents: true
   cost: 1
-  category: SpeechTraits
+  category: ReplacementSpeechTraits
   components:
     - type: Speech
       speechVerb: Vox
@@ -101,8 +101,8 @@
   name: trait-arachnidvocals-name
   description: trait-arachnidvocals-desc
   replaceComponents: true
-  cost: 2
-  category: SpeechTraits
+  cost: 1
+  category: ReplacementSpeechTraits
   components:
     - type: Speech
       speechVerb: Arachnid
@@ -119,8 +119,8 @@
   name: trait-dionavocals-name
   description: trait-dionavocals-desc
   replaceComponents: true
-  cost: 2
-  category: SpeechTraits
+  cost: 1
+  category: ReplacementSpeechTraits
   components:
     - type: Speech
       speechSounds: Alto
@@ -136,8 +136,8 @@
   name: trait-dwarfvocals-name
   description: trait-dwarfvocals-desc
   replaceComponents: true
-  cost: 2
-  category: SpeechTraits
+  cost: 1
+  category: ReplacementSpeechTraits
   components:
     - type: Speech
       speechSounds: Bass
@@ -155,8 +155,8 @@
   name: trait-humanvocals-name
   description: trait-humanvocals-desc
   replaceComponents: true
-  cost: 2
-  category: SpeechTraits
+  cost: 1
+  category: ReplacementSpeechTraits
   components:
     - type: Speech
       speechSounds: Alto
@@ -172,8 +172,8 @@
   name: trait-mothvocals-name
   description: trait-mothvocals-desc
   replaceComponents: true
-  cost: 2
-  category: SpeechTraits
+  cost: 1
+  category: ReplacementSpeechTraits
   components:
     - type: MothAccent
     - type: Speech
@@ -191,8 +191,8 @@
   name: trait-reptilianvocals-name
   description: trait-reptilianvocals-desc
   replaceComponents: true
-  cost: 2
-  category: SpeechTraits
+  cost: 1
+  category: ReplacementSpeechTraits
   components:
     - type: LizardAccent
     - type: Speech
@@ -209,8 +209,8 @@
   name: trait-slimevocals-name
   description: trait-slimevocals-desc
   replaceComponents: true
-  cost: 2
-  category: SpeechTraits
+  cost: 1
+  category: ReplacementSpeechTraits
   components:
     - type: Speech
       speechVerb: Slime
@@ -227,8 +227,8 @@
   name: trait-voxvocals-name
   description: trait-voxvocals-desc
   replaceComponents: true
-  cost: 2
-  category: SpeechTraits
+  cost: 1
+  category: ReplacementSpeechTraits
   components:
     - type: Speech
       speechVerb: Vox

--- a/Resources/Prototypes/_Umbra/Traits/categories.yml
+++ b/Resources/Prototypes/_Umbra/Traits/categories.yml
@@ -1,0 +1,4 @@
+- type: traitCategory
+  id: ReplacementSpeechTraits
+  name: trait-category-replacement-speech
+  maxTraitPoints: 1


### PR DESCRIPTION
## About the PR
Ports https://github.com/ss14-harmony/ss14-harmony/pull/149 from Harmony! Now you can have a voice, or speech patterns of other races. 

These only include base game races for now, no Umbra/CD specific ones.

## Why / Balance
Character Customisation is always welcome.

## Technical details
Added from Harmony but using Umbra namespace for the new category. Categories are currently **FULLY UNSORTED** and will require a fix upstream.

## Media
<img width="322" height="431" alt="image" src="https://github.com/user-attachments/assets/5c31fa0d-ee61-47c7-b694-f7971862dd03" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
N/A

**Changelog**
Ports over the Raised By and Voice of character Traits from Harmony! Please find them at the bottom of the traits list. These are also changed to allow you to have accents as well.
